### PR TITLE
feat: full assisted pipeline — stages, gates, orchestrator, CLI

### DIFF
--- a/config/templates/manim_scene.py.j2
+++ b/config/templates/manim_scene.py.j2
@@ -1,0 +1,25 @@
+"""Manim visualization for {{ algorithm_name }}."""
+
+from __future__ import annotations
+
+from manim import *
+
+
+class {{ class_name }}Scene(Scene):
+    """Animated visualization of the {{ algorithm_name }} algorithm."""
+
+    # Color palette matching no-magic style
+    HIGHLIGHT_COLOR = YELLOW
+    COMPARE_COLOR = RED
+    SWAP_COLOR = GREEN
+    DONE_COLOR = BLUE
+
+    def construct(self) -> None:
+        title = Text("{{ algorithm_name }}", font_size=36)
+        self.play(Write(title))
+        self.wait(0.5)
+        self.play(title.animate.to_edge(UP))
+
+        {{ animation_steps }}
+
+        self.wait(1)

--- a/src/apprentice/cli.py
+++ b/src/apprentice/cli.py
@@ -8,10 +8,11 @@ import sys
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from apprentice.core.config import ApprenticeConfig
+    from apprentice.core.pipeline import PipelineResult
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,13 +31,18 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers = parser.add_subparsers(dest="command")
 
-    build_parser = subparsers.add_parser("build", help="Run implementation stage for an algorithm")
+    build_parser = subparsers.add_parser("build", help="Run full pipeline for an algorithm")
     build_parser.add_argument("algorithm", help="Algorithm name to build")
     build_parser.add_argument("--tier", type=int, default=2, help="Algorithm tier (default: 2)")
     build_parser.add_argument(
         "--description", type=str, default="", help="Optional algorithm description"
     )
 
+    suggest_parser = subparsers.add_parser("suggest", help="Discover candidate algorithms")
+    suggest_parser.add_argument("--tier", type=int, default=2, help="Target tier (default: 2)")
+    suggest_parser.add_argument("--limit", type=int, default=5, help="Max candidates (default: 5)")
+
+    subparsers.add_parser("preview", help="Inspect last build artifacts")
     subparsers.add_parser("status", help="Show budget usage and queue state")
     subparsers.add_parser("config", help="Display current configuration")
 
@@ -50,6 +56,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "build":
         return _cmd_build(cfg, args.algorithm, args.tier, args.description)
+    if args.command == "suggest":
+        return _cmd_suggest(cfg, args.tier, args.limit)
+    if args.command == "preview":
+        return _cmd_preview()
     if args.command == "status":
         return _cmd_status(cfg)
     if args.command == "config":
@@ -73,16 +83,67 @@ def _load_cfg(config_path: Path | None) -> ApprenticeConfig:
     return cfg
 
 
-def _cmd_build(cfg: ApprenticeConfig, algorithm: str, tier: int, description: str) -> int:
-    from apprentice.core.observability import get_logger, log_stage_metrics
-    from apprentice.models.work_item import PipelineContext, WorkItem, WorkItemSource
+def _create_pipeline(cfg: ApprenticeConfig) -> tuple[Any, Any, Any]:
+    """Create pipeline with all stages and gates wired."""
+    from apprentice.core.pipeline import Pipeline, PipelineConfig
+    from apprentice.gates.consistency import ConsistencyGate
+    from apprentice.gates.correctness import CorrectnessGate
+    from apprentice.gates.lint import LintGate
+    from apprentice.gates.schema_compliance import SchemaComplianceGate
     from apprentice.providers import create_provider
+    from apprentice.stages.assessment import AssessmentStage
     from apprentice.stages.implementation import ImplementationStage
+    from apprentice.stages.instrumentation import InstrumentationStage
+    from apprentice.stages.validation import ValidationStage
+    from apprentice.stages.visualization import VisualizationStage
+
+    provider = create_provider(cfg.provider.default, cfg.provider.model)
+
+    stages: dict[str, Any] = {
+        "implementation": ImplementationStage(),
+        "instrumentation": InstrumentationStage(),
+        "visualization": VisualizationStage(),
+        "assessment": AssessmentStage(),
+        "validation": ValidationStage(),
+    }
+
+    gates: dict[str, Any] = {
+        "lint": LintGate(),
+        "correctness": CorrectnessGate(),
+        "consistency": ConsistencyGate(),
+        "schema_compliance": SchemaComplianceGate(),
+    }
+
+    pipeline_config = PipelineConfig(
+        stages=[
+            "implementation",
+            "instrumentation",
+            "visualization",
+            "assessment",
+            "validation",
+        ],
+        gates={
+            "lint": ["implementation"],
+            "correctness": ["implementation"],
+            "consistency": ["validation"],
+            "schema_compliance": ["validation"],
+        },
+        parallel_stages=[["instrumentation", "visualization", "assessment"]],
+        budget_per_stage=cfg.budget.stage.max_tokens_per_stage,
+    )
+
+    pipeline = Pipeline(stages=stages, gates=gates, config=pipeline_config)
+    return pipeline, provider, pipeline_config
+
+
+def _cmd_build(cfg: ApprenticeConfig, algorithm: str, tier: int, description: str) -> int:
+    from apprentice.core.observability import get_logger
+    from apprentice.models.work_item import PipelineContext, WorkItem, WorkItemSource
 
     logger = get_logger(__name__)
     logger.info("build started: %s (tier %d)", algorithm, tier)
 
-    provider = create_provider(cfg.provider.default, cfg.provider.model)
+    pipeline, provider, _ = _create_pipeline(cfg)
 
     work_item = WorkItem(
         id=f"manual-{algorithm}",
@@ -90,48 +151,84 @@ def _cmd_build(cfg: ApprenticeConfig, algorithm: str, tier: int, description: st
         tier=tier,
         source=WorkItemSource.MANUAL,
         rationale=description,
-        allocated_tokens=cfg.budget.stage.max_tokens_per_stage,
+        allocated_tokens=cfg.budget.cycle.max_tokens_per_cycle,
     )
 
     context = PipelineContext(
-        config={"provider": provider, "references": []},
+        config={"provider": provider, "references": [], "artifacts": {}},
+        budget_remaining_tokens=cfg.budget.cycle.max_tokens_per_cycle,
+        budget_remaining_usd=cfg.budget.cycle.max_cost_per_cycle_usd,
+    )
+
+    start = time.monotonic()
+    result = pipeline.run(work_item, context)
+    elapsed = time.monotonic() - start
+
+    _print_pipeline_result(result, elapsed)
+    return 0 if result.success else 1
+
+
+def _cmd_suggest(cfg: ApprenticeConfig, tier: int, limit: int) -> int:
+    from apprentice.core.observability import get_logger
+    from apprentice.models.work_item import PipelineContext, WorkItem, WorkItemSource
+    from apprentice.providers import create_provider
+    from apprentice.stages.discovery import DiscoveryStage
+
+    logger = get_logger(__name__)
+    logger.info("suggesting algorithms for tier %d (limit %d)", tier, limit)
+
+    provider = create_provider(cfg.provider.default, cfg.provider.model)
+
+    work_item = WorkItem(
+        id=f"suggest-tier-{tier}",
+        algorithm_name=f"discovery-tier-{tier}",
+        tier=tier,
+        source=WorkItemSource.DISCOVERY,
+        rationale=f"Suggest up to {limit} algorithms for tier {tier}",
+    )
+
+    context = PipelineContext(
+        config={"provider": provider, "limit": limit},
         budget_remaining_tokens=cfg.budget.stage.max_tokens_per_stage,
         budget_remaining_usd=cfg.budget.cycle.max_cost_per_cycle_usd,
     )
 
-    stage = ImplementationStage()
-
-    estimate = stage.estimate_cost(work_item)
-    logger.info(
-        "cost estimate: %d input + %d output tokens, $%.6f",
-        estimate.estimated_input_tokens,
-        estimate.estimated_output_tokens,
-        estimate.estimated_cost_usd,
-    )
-
-    start = time.monotonic()
+    stage = DiscoveryStage()
     result = stage.execute(work_item, context)
-    elapsed = time.monotonic() - start
-
-    log_stage_metrics(
-        stage_name=stage.name,
-        tokens_used=result.tokens_used,
-        cost_usd=result.cost_usd,
-        duration_seconds=elapsed,
-        passed=True,
-    )
 
     _print_json(
         {
-            "algorithm": algorithm,
             "tier": tier,
-            "artifacts": result.artifacts,
+            "candidates_file": result.artifacts.get("discovery", ""),
             "tokens_used": result.tokens_used,
             "cost_usd": result.cost_usd,
-            "duration_seconds": round(elapsed, 2),
             "diagnostics": result.diagnostics,
         }
     )
+    return 0
+
+
+def _cmd_preview() -> int:
+    import tempfile
+
+    artifacts_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    if not artifacts_dir.exists():
+        _print_json({"error": "No artifacts found. Run 'apprentice build' first."})
+        return 1
+
+    files = sorted(artifacts_dir.iterdir())
+    artifacts: dict[str, dict[str, Any]] = {}
+    for f in files:
+        if f.is_file():
+            content = f.read_text(encoding="utf-8")
+            preview = content[:500] + ("..." if len(content) > 500 else "")
+            artifacts[f.name] = {
+                "path": str(f),
+                "size_bytes": f.stat().st_size,
+                "preview": preview,
+            }
+
+    _print_json({"artifacts_dir": str(artifacts_dir), "files": artifacts})
     return 0
 
 
@@ -141,6 +238,7 @@ def _cmd_status(cfg: ApprenticeConfig) -> int:
             "budget": {
                 "monthly_token_ceiling": cfg.budget.global_budget.monthly_token_ceiling,
                 "monthly_cost_ceiling_usd": cfg.budget.global_budget.monthly_cost_ceiling_usd,
+                "cycle_token_cap": cfg.budget.cycle.max_tokens_per_cycle,
                 "stage_token_cap": cfg.budget.stage.max_tokens_per_stage,
             },
             "rate_limits": {
@@ -158,6 +256,31 @@ def _cmd_status(cfg: ApprenticeConfig) -> int:
 def _cmd_config(cfg: ApprenticeConfig) -> int:
     _print_json(asdict(cfg))
     return 0
+
+
+def _print_pipeline_result(result: PipelineResult, elapsed: float) -> None:
+    bundle = result.artifacts
+    _print_json(
+        {
+            "success": result.success,
+            "work_item": {
+                "id": result.work_item.id,
+                "algorithm": result.work_item.algorithm_name,
+                "status": result.work_item.status.value,
+            },
+            "artifacts": {
+                "implementation": bundle.implementation_path,
+                "instrumented": bundle.instrumented_path,
+                "manim_scene": bundle.manim_scene_path,
+                "anki_deck": bundle.anki_deck_path,
+            },
+            "stages_run": len(result.stage_results),
+            "gates_run": len(result.gate_results),
+            "total_tokens": result.total_tokens,
+            "total_cost_usd": result.total_cost_usd,
+            "duration_seconds": round(elapsed, 2),
+        }
+    )
 
 
 def _print_json(data: object) -> None:

--- a/src/apprentice/core/pipeline.py
+++ b/src/apprentice/core/pipeline.py
@@ -1,3 +1,419 @@
 """Config-driven stage sequencer."""
 
 from __future__ import annotations
+
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from apprentice.core.observability import get_logger, log_gate_result, log_stage_metrics
+from apprentice.models.artifact import ArtifactBundle
+from apprentice.models.budget import CostEstimate
+from apprentice.models.work_item import (
+    GateResult,
+    GateVerdict,
+    PipelineContext,
+    StageResult,
+    WorkItem,
+    WorkItemStatus,
+)
+
+if TYPE_CHECKING:
+    from apprentice.gates.base import GateInterface
+    from apprentice.stages.base import StageInterface
+
+_logger = get_logger(__name__)
+
+
+@dataclass
+class PipelineConfig:
+    """Defines stage ordering and gate insertion points."""
+
+    stages: list[str]  # ordered stage names
+    gates: dict[str, list[str]]  # gate_name -> runs after these stages
+    parallel_stages: list[list[str]]  # groups of stages to run in parallel
+    budget_per_stage: int  # token cap per stage
+
+
+@dataclass
+class PipelineResult:
+    """Aggregated result of a full pipeline run."""
+
+    work_item: WorkItem
+    artifacts: ArtifactBundle
+    gate_results: list[GateResult]
+    stage_results: list[StageResult]
+    total_tokens: int
+    total_cost_usd: float
+    success: bool
+
+
+def _merge_stage_result_into_bundle(bundle: ArtifactBundle, result: StageResult) -> None:
+    """Write known artifact keys from a StageResult into the bundle in-place."""
+    key_to_field: dict[str, str] = {
+        "implementation": "implementation_path",
+        "instrumented": "instrumented_path",
+        "manim_scene": "manim_scene_path",
+        "anki_deck": "anki_deck_path",
+        "readme_section": "readme_section",
+        "pr_url": "pr_url",
+    }
+    for key, value in result.artifacts.items():
+        field = key_to_field.get(key)
+        if field is not None:
+            setattr(bundle, field, value)
+
+
+def _gates_for_stage(
+    stage_name: str,
+    gates_config: dict[str, list[str]],
+) -> list[str]:
+    """Return gate names that should fire after the given stage completes."""
+    return [
+        gate_name for gate_name, after_stages in gates_config.items() if stage_name in after_stages
+    ]
+
+
+class Pipeline:
+    """Orchestrates stages and gates according to a PipelineConfig."""
+
+    def __init__(
+        self,
+        stages: dict[str, StageInterface],
+        gates: dict[str, GateInterface],
+        config: PipelineConfig,
+    ) -> None:
+        self._stages = stages
+        self._gates = gates
+        self._config = config
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _budget_pre_check(
+        self,
+        stage_name: str,
+        estimate: CostEstimate,
+        context: PipelineContext,
+        work_item: WorkItem,
+    ) -> bool:
+        """Return True if budget is sufficient; False if the item must be shelved."""
+        estimated_total = estimate.estimated_input_tokens + estimate.estimated_output_tokens
+        if estimated_total > self._config.budget_per_stage:
+            _logger.warning(
+                "budget_pre_check_failed: estimated tokens exceed per-stage cap",
+                extra={
+                    "stage_name": stage_name,
+                    "estimated_tokens": estimated_total,
+                    "budget_per_stage": self._config.budget_per_stage,
+                    "work_item_id": work_item.id,
+                },
+            )
+            return False
+        if estimated_total > context.budget_remaining_tokens:
+            _logger.warning(
+                "budget_pre_check_failed: insufficient tokens remaining",
+                extra={
+                    "stage_name": stage_name,
+                    "estimated_tokens": estimated_total,
+                    "budget_remaining_tokens": context.budget_remaining_tokens,
+                    "work_item_id": work_item.id,
+                },
+            )
+            return False
+        if estimate.estimated_cost_usd > context.budget_remaining_usd:
+            _logger.warning(
+                "budget_pre_check_failed: insufficient USD remaining",
+                extra={
+                    "stage_name": stage_name,
+                    "estimated_cost_usd": estimate.estimated_cost_usd,
+                    "budget_remaining_usd": context.budget_remaining_usd,
+                    "work_item_id": work_item.id,
+                },
+            )
+            return False
+        return True
+
+    def _run_single_stage(
+        self,
+        stage_name: str,
+        work_item: WorkItem,
+        context: PipelineContext,
+    ) -> StageResult | None:
+        """Execute one stage; return StageResult on success or None on exception."""
+        stage = self._stages[stage_name]
+        start = time.monotonic()
+        try:
+            result = stage.execute(work_item, context)
+        except Exception:
+            duration = time.monotonic() - start
+            _logger.exception(
+                "stage_exception",
+                extra={
+                    "stage_name": stage_name,
+                    "work_item_id": work_item.id,
+                    "duration_seconds": duration,
+                },
+            )
+            log_stage_metrics(
+                stage_name=stage_name,
+                tokens_used=0,
+                cost_usd=0.0,
+                duration_seconds=duration,
+                passed=False,
+            )
+            return None
+        duration = time.monotonic() - start
+        log_stage_metrics(
+            stage_name=stage_name,
+            tokens_used=result.tokens_used,
+            cost_usd=result.cost_usd,
+            duration_seconds=duration,
+            passed=True,
+        )
+        return result
+
+    def _run_parallel_group(
+        self,
+        group: list[str],
+        work_item: WorkItem,
+        context: PipelineContext,
+    ) -> list[StageResult]:
+        """Run a group of stages concurrently; return all successful results."""
+        results: list[StageResult] = []
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = {
+                executor.submit(self._run_single_stage, name, work_item, context): name
+                for name in group
+                if name in self._stages
+            }
+            for future in as_completed(futures):
+                stage_name = futures[future]
+                result = future.result()
+                if result is None:
+                    _logger.error(
+                        "parallel_stage_failed",
+                        extra={"stage_name": stage_name, "work_item_id": work_item.id},
+                    )
+                else:
+                    results.append(result)
+        return results
+
+    def _evaluate_gates(
+        self,
+        after_stage: str,
+        work_item: WorkItem,
+        artifacts: ArtifactBundle,
+    ) -> tuple[list[GateResult], bool]:
+        """
+        Evaluate all gates configured to fire after ``after_stage``.
+
+        Returns (gate_results, should_stop) where should_stop is True when a
+        blocking gate FAIL is encountered.
+        """
+        gate_results: list[GateResult] = []
+        for gate_name in _gates_for_stage(after_stage, self._config.gates):
+            gate = self._gates.get(gate_name)
+            if gate is None:
+                _logger.warning(
+                    "gate_not_registered",
+                    extra={"gate_name": gate_name, "after_stage": after_stage},
+                )
+                continue
+            try:
+                result = gate.evaluate(work_item, artifacts)
+            except Exception:
+                _logger.exception(
+                    "gate_exception",
+                    extra={"gate_name": gate_name, "work_item_id": work_item.id},
+                )
+                continue
+            log_gate_result(
+                gate_name=gate_name,
+                verdict=result.verdict.value,
+                diagnostics=result.diagnostics,
+            )
+            gate_results.append(result)
+            if result.verdict == GateVerdict.FAIL and gate.blocking:
+                _logger.error(
+                    "blocking_gate_failed",
+                    extra={
+                        "gate_name": gate_name,
+                        "work_item_id": work_item.id,
+                        "diagnostics": result.diagnostics,
+                    },
+                )
+                return gate_results, True
+            if result.verdict == GateVerdict.WARN:
+                _logger.warning(
+                    "gate_warning",
+                    extra={
+                        "gate_name": gate_name,
+                        "work_item_id": work_item.id,
+                        "diagnostics": result.diagnostics,
+                    },
+                )
+        return gate_results, False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, work_item: WorkItem, context: PipelineContext) -> PipelineResult:
+        """Orchestrate the full pipeline and return a PipelineResult."""
+        work_item.status = WorkItemStatus.IN_PROGRESS
+
+        bundle = ArtifactBundle(
+            id=str(uuid.uuid4()),
+            work_item_id=work_item.id,
+        )
+
+        all_stage_results: list[StageResult] = []
+        all_gate_results: list[GateResult] = []
+        total_tokens = 0
+        total_cost_usd = 0.0
+
+        # Build a set of stage names that belong to parallel groups so we
+        # can skip them when iterating the sequential stage list.
+        parallel_stage_names: set[str] = {
+            name for group in self._config.parallel_stages for name in group
+        }
+
+        def _process_stage_result(
+            stage_name: str,
+            result: StageResult | None,
+        ) -> bool:
+            """Update shared state and evaluate gates. Return False to stop pipeline."""
+            nonlocal total_tokens, total_cost_usd
+            if result is None:
+                return True  # stage exception already logged; continue pipeline
+            context.budget_remaining_tokens -= result.tokens_used
+            context.budget_remaining_usd -= result.cost_usd
+            total_tokens += result.tokens_used
+            total_cost_usd += result.cost_usd
+            work_item.actual_tokens += result.tokens_used
+            _merge_stage_result_into_bundle(bundle, result)
+            all_stage_results.append(result)
+
+            gate_results, should_stop = self._evaluate_gates(stage_name, work_item, bundle)
+            all_gate_results.extend(gate_results)
+            return not should_stop
+
+        for stage_name in self._config.stages:
+            # Parallel groups are handled separately below; skip individual names.
+            if stage_name in parallel_stage_names:
+                continue
+
+            stage = self._stages.get(stage_name)
+            if stage is None:
+                _logger.warning(
+                    "stage_not_registered",
+                    extra={"stage_name": stage_name, "work_item_id": work_item.id},
+                )
+                continue
+
+            # Budget pre-check
+            try:
+                estimate: CostEstimate = stage.estimate_cost(work_item)
+            except Exception:
+                _logger.exception(
+                    "estimate_cost_exception",
+                    extra={"stage_name": stage_name, "work_item_id": work_item.id},
+                )
+                estimate = CostEstimate(
+                    estimated_input_tokens=0,
+                    estimated_output_tokens=0,
+                    estimated_cost_usd=0.0,
+                )
+
+            if not self._budget_pre_check(stage_name, estimate, context, work_item):
+                work_item.status = WorkItemStatus.SHELVED
+                work_item.last_failed_stage = stage_name
+                return PipelineResult(
+                    work_item=work_item,
+                    artifacts=bundle,
+                    gate_results=all_gate_results,
+                    stage_results=all_stage_results,
+                    total_tokens=total_tokens,
+                    total_cost_usd=total_cost_usd,
+                    success=False,
+                )
+
+            result = self._run_single_stage(stage_name, work_item, context)
+            if not _process_stage_result(stage_name, result):
+                work_item.status = WorkItemStatus.SHELVED
+                work_item.last_failed_stage = stage_name
+                return PipelineResult(
+                    work_item=work_item,
+                    artifacts=bundle,
+                    gate_results=all_gate_results,
+                    stage_results=all_stage_results,
+                    total_tokens=total_tokens,
+                    total_cost_usd=total_cost_usd,
+                    success=False,
+                )
+
+        # Run parallel groups
+        for group in self._config.parallel_stages:
+            # Validate budget against each stage in the group individually
+            for stage_name in group:
+                stage = self._stages.get(stage_name)
+                if stage is None:
+                    continue
+                try:
+                    estimate = stage.estimate_cost(work_item)
+                except Exception:
+                    _logger.exception(
+                        "estimate_cost_exception",
+                        extra={"stage_name": stage_name, "work_item_id": work_item.id},
+                    )
+                    estimate = CostEstimate(
+                        estimated_input_tokens=0,
+                        estimated_output_tokens=0,
+                        estimated_cost_usd=0.0,
+                    )
+                if not self._budget_pre_check(stage_name, estimate, context, work_item):
+                    work_item.status = WorkItemStatus.SHELVED
+                    work_item.last_failed_stage = stage_name
+                    return PipelineResult(
+                        work_item=work_item,
+                        artifacts=bundle,
+                        gate_results=all_gate_results,
+                        stage_results=all_stage_results,
+                        total_tokens=total_tokens,
+                        total_cost_usd=total_cost_usd,
+                        success=False,
+                    )
+
+            parallel_results = self._run_parallel_group(group, work_item, context)
+            for stage_result in parallel_results:
+                # Evaluate gates per stage within the group
+                if not _process_stage_result(stage_result.stage_name, stage_result):
+                    work_item.status = WorkItemStatus.SHELVED
+                    work_item.last_failed_stage = stage_result.stage_name
+                    return PipelineResult(
+                        work_item=work_item,
+                        artifacts=bundle,
+                        gate_results=all_gate_results,
+                        stage_results=all_stage_results,
+                        total_tokens=total_tokens,
+                        total_cost_usd=total_cost_usd,
+                        success=False,
+                    )
+
+        work_item.status = WorkItemStatus.COMPLETED
+        work_item.completed_at = datetime.now()
+
+        return PipelineResult(
+            work_item=work_item,
+            artifacts=bundle,
+            gate_results=all_gate_results,
+            stage_results=all_stage_results,
+            total_tokens=total_tokens,
+            total_cost_usd=total_cost_usd,
+            success=True,
+        )

--- a/src/apprentice/gates/consistency.py
+++ b/src/apprentice/gates/consistency.py
@@ -1,3 +1,249 @@
 """Consistency gate — cross-artifact structural and semantic validation."""
 
 from __future__ import annotations
+
+import ast
+import csv
+import io
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+_ANKI_REQUIRED_COLUMNS = 4
+_COMPLEXITY_PATTERN = re.compile(r"O\([^)]+\)")
+
+
+def _extract_implementation_docstring(source: str) -> str:
+    """Return the module-level docstring from Python source, or empty string."""
+    try:
+        tree = ast.parse(source)
+        return ast.get_docstring(tree) or ""
+    except SyntaxError:
+        return ""
+
+
+def _extract_complexity_notation(text: str) -> list[str]:
+    """Return all Big-O complexity tokens found in the text."""
+    return _COMPLEXITY_PATTERN.findall(text)
+
+
+def _anki_column_count_ok(csv_content: str) -> bool:
+    """Return True if every non-empty row in the CSV has exactly 4 columns."""
+    reader = csv.reader(io.StringIO(csv_content))
+    for row in reader:
+        if not row:
+            continue
+        if len(row) != _ANKI_REQUIRED_COLUMNS:
+            return False
+    return True
+
+
+class ConsistencyGate:
+    """Validate cross-artifact structural and semantic consistency."""
+
+    name = "consistency"
+    max_retries = 0
+    blocking = True
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        """Check that all present artifacts are internally and mutually consistent.
+
+        Args:
+            work_item: The work item being evaluated.
+            artifacts: Bundle of generated artifacts.
+
+        Returns:
+            GateResult with PASS, FAIL (structural), or WARN (semantic) plus per-check diagnostics.
+        """
+        checks: list[dict[str, Any]] = []
+        structural_fail = False
+        semantic_warn = False
+
+        algorithm_name = work_item.algorithm_name
+
+        # --- Structural checks ---
+
+        # Implementation: file must exist and be valid Python
+        impl_path_str = artifacts.implementation_path
+        impl_source: str | None = None
+        if impl_path_str:
+            impl_path = Path(impl_path_str)
+            if not impl_path.exists():
+                checks.append(
+                    {
+                        "check": "implementation_exists",
+                        "passed": False,
+                        "detail": f"implementation file not found: {impl_path_str}",
+                    }
+                )
+                structural_fail = True
+            else:
+                checks.append({"check": "implementation_exists", "passed": True})
+                try:
+                    impl_source = impl_path.read_text(encoding="utf-8")
+                    ast.parse(impl_source)
+                    checks.append({"check": "implementation_valid_python", "passed": True})
+                except SyntaxError as exc:
+                    checks.append(
+                        {
+                            "check": "implementation_valid_python",
+                            "passed": False,
+                            "detail": str(exc),
+                        }
+                    )
+                    structural_fail = True
+
+        # Instrumented: if path given, must exist
+        instr_path_str = artifacts.instrumented_path
+        if instr_path_str:
+            instr_exists = Path(instr_path_str).exists()
+            checks.append(
+                {
+                    "check": "instrumented_exists",
+                    "passed": instr_exists,
+                    "detail": None
+                    if instr_exists
+                    else f"instrumented file not found: {instr_path_str}",
+                }
+            )
+            if not instr_exists:
+                structural_fail = True
+
+        # Manim: if path given, must exist
+        manim_path_str = artifacts.manim_scene_path
+        if manim_path_str:
+            manim_exists = Path(manim_path_str).exists()
+            checks.append(
+                {
+                    "check": "manim_exists",
+                    "passed": manim_exists,
+                    "detail": None if manim_exists else f"manim file not found: {manim_path_str}",
+                }
+            )
+            if not manim_exists:
+                structural_fail = True
+
+        # Anki CSV: if path given, must exist and have correct column count
+        anki_path_str = artifacts.anki_deck_path
+        anki_content: str | None = None
+        if anki_path_str:
+            anki_path = Path(anki_path_str)
+            if not anki_path.exists():
+                checks.append(
+                    {
+                        "check": "anki_exists",
+                        "passed": False,
+                        "detail": f"anki file not found: {anki_path_str}",
+                    }
+                )
+                structural_fail = True
+            else:
+                checks.append({"check": "anki_exists", "passed": True})
+                anki_content = anki_path.read_text(encoding="utf-8")
+                columns_ok = _anki_column_count_ok(anki_content)
+                checks.append(
+                    {
+                        "check": "anki_column_count",
+                        "passed": columns_ok,
+                        "detail": None
+                        if columns_ok
+                        else f"anki CSV rows must have {_ANKI_REQUIRED_COLUMNS} columns",
+                    }
+                )
+                if not columns_ok:
+                    structural_fail = True
+
+        # --- Semantic checks (advisory) ---
+
+        # Algorithm name in implementation docstring
+        if impl_source is not None:
+            impl_docstring = _extract_implementation_docstring(impl_source)
+            name_in_doc = algorithm_name.lower() in impl_docstring.lower()
+            checks.append(
+                {
+                    "check": "name_in_implementation_docstring",
+                    "passed": name_in_doc,
+                    "detail": None
+                    if name_in_doc
+                    else (
+                        f"algorithm name '{algorithm_name}' not found in implementation docstring"
+                    ),
+                }
+            )
+            if not name_in_doc:
+                semantic_warn = True
+
+            # Complexity consistency between implementation docstring and anki
+            if anki_content is not None:
+                impl_complexities = _extract_complexity_notation(impl_docstring)
+                if impl_complexities:
+                    anki_text = anki_content
+                    anki_has_complexity = any(c in anki_text for c in impl_complexities)
+                    checks.append(
+                        {
+                            "check": "complexity_consistency",
+                            "passed": anki_has_complexity,
+                            "detail": None
+                            if anki_has_complexity
+                            else (
+                                f"complexity {impl_complexities} from docstring not found in anki cards"
+                            ),
+                        }
+                    )
+                    if not anki_has_complexity:
+                        semantic_warn = True
+
+        # Algorithm name in manim scene class name
+        if manim_path_str and Path(manim_path_str).exists():
+            manim_source = Path(manim_path_str).read_text(encoding="utf-8")
+            name_slug = algorithm_name.lower().replace(" ", "").replace("-", "").replace("_", "")
+            class_names_lower = "".join(
+                c.lower() for c in re.findall(r"class\s+(\w+)", manim_source)
+            )
+            name_in_scene = name_slug in class_names_lower
+            checks.append(
+                {
+                    "check": "name_in_manim_scene_class",
+                    "passed": name_in_scene,
+                    "detail": None
+                    if name_in_scene
+                    else (
+                        f"algorithm name '{algorithm_name}' not found in any manim scene class name"
+                    ),
+                }
+            )
+            if not name_in_scene:
+                semantic_warn = True
+
+        # Algorithm name in anki content
+        if anki_content is not None:
+            name_in_anki = algorithm_name.lower() in anki_content.lower()
+            checks.append(
+                {
+                    "check": "name_in_anki_cards",
+                    "passed": name_in_anki,
+                    "detail": None
+                    if name_in_anki
+                    else (f"algorithm name '{algorithm_name}' not found in anki cards"),
+                }
+            )
+            if not name_in_anki:
+                semantic_warn = True
+
+        if structural_fail:
+            verdict = GateVerdict.FAIL
+        elif semantic_warn:
+            verdict = GateVerdict.WARN
+        else:
+            verdict = GateVerdict.PASS
+
+        return GateResult(
+            gate_name=self.name,
+            verdict=verdict,
+            diagnostics={"checks": checks},
+        )

--- a/src/apprentice/gates/correctness.py
+++ b/src/apprentice/gates/correctness.py
@@ -1,3 +1,85 @@
 """Correctness gate — reference test execution, 1 retry with re-prompt."""
 
 from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+_EXECUTION_TIMEOUT = 5  # seconds
+
+
+class CorrectnessGate:
+    """Execute the implementation file and validate it exits cleanly."""
+
+    name = "correctness"
+    max_retries = 1
+    blocking = True
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        """Execute the implementation file and check its exit code.
+
+        Args:
+            work_item: The work item being evaluated.
+            artifacts: Bundle of generated artifacts.
+
+        Returns:
+            GateResult with PASS or FAIL and stdout/stderr diagnostics.
+        """
+        diagnostics: dict[str, Any] = {}
+
+        path_str = artifacts.implementation_path
+        if not path_str:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={"error": "implementation_path is empty"},
+            )
+
+        path = Path(path_str)
+        if not path.exists():
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={"error": f"file not found: {path_str}"},
+            )
+
+        source = path.read_text(encoding="utf-8")
+        has_main_block = (
+            'if __name__ == "__main__"' in source or "if __name__ == '__main__'" in source
+        )
+        diagnostics["has_main_block"] = has_main_block
+
+        try:
+            result = subprocess.run(
+                [sys.executable, str(path)],
+                capture_output=True,
+                timeout=_EXECUTION_TIMEOUT,
+                text=True,
+            )
+        except subprocess.TimeoutExpired:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={
+                    **diagnostics,
+                    "error": f"execution timed out after {_EXECUTION_TIMEOUT}s",
+                },
+            )
+
+        diagnostics["return_code"] = result.returncode
+        diagnostics["stdout"] = result.stdout
+        diagnostics["stderr"] = result.stderr
+
+        verdict = GateVerdict.PASS if result.returncode == 0 else GateVerdict.FAIL
+        return GateResult(
+            gate_name=self.name,
+            verdict=verdict,
+            diagnostics=diagnostics,
+        )

--- a/src/apprentice/gates/lint.py
+++ b/src/apprentice/gates/lint.py
@@ -1,3 +1,183 @@
 """Lint and style gate — ruff + structural checks, max 2 auto-fix retries."""
 
 from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+_MAX_FILE_LINES = 500
+
+
+def _has_wildcard_import(tree: ast.Module) -> bool:
+    """Return True if the module contains any wildcard import."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.names
+            and any(alias.name == "*" for alias in node.names)
+        ):
+            return True
+    return False
+
+
+def _collect_public_functions(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return top-level public function definitions."""
+    results: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Module):
+            for child in ast.iter_child_nodes(node):
+                if isinstance(
+                    child, ast.FunctionDef | ast.AsyncFunctionDef
+                ) and not child.name.startswith("_"):
+                    results.append(child)
+    return results
+
+
+def _function_has_full_annotations(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True if all parameters and the return have type annotations."""
+    args = func.args
+    all_params = (
+        args.posonlyargs
+        + args.args
+        + args.kwonlyargs
+        + ([args.vararg] if args.vararg else [])
+        + ([args.kwarg] if args.kwarg else [])
+    )
+    for arg in all_params:
+        if arg.arg == "self":
+            continue
+        if arg.annotation is None:
+            return False
+    return func.returns is not None
+
+
+class LintGate:
+    """Check implementation files for style and structural requirements."""
+
+    name = "lint"
+    max_retries = 2
+    blocking = True
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        """Evaluate the implementation file against lint and style rules.
+
+        Args:
+            work_item: The work item being evaluated.
+            artifacts: Bundle of generated artifacts.
+
+        Returns:
+            GateResult with PASS, FAIL, or WARN and per-check diagnostics.
+        """
+        checks: list[dict[str, Any]] = []
+        failed = False
+
+        path_str = artifacts.implementation_path
+        if not path_str:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={"checks": [], "error": "implementation_path is empty"},
+            )
+
+        path = Path(path_str)
+        if not path.exists():
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={
+                    "checks": [],
+                    "error": f"file not found: {path_str}",
+                },
+            )
+
+        source = path.read_text(encoding="utf-8")
+
+        # Syntax check via AST parse
+        try:
+            tree = ast.parse(source, filename=str(path))
+            checks.append({"check": "syntax", "passed": True})
+        except SyntaxError as exc:
+            checks.append({"check": "syntax", "passed": False, "detail": str(exc)})
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={"checks": checks},
+            )
+
+        # Module-level docstring
+        module_docstring = ast.get_docstring(tree)
+        has_module_doc = module_docstring is not None
+        checks.append(
+            {
+                "check": "module_docstring",
+                "passed": has_module_doc,
+                "detail": None if has_module_doc else "missing module-level docstring",
+            }
+        )
+        if not has_module_doc:
+            failed = True
+
+        # Public functions: docstrings and annotations
+        public_funcs = _collect_public_functions(tree)
+        for func in public_funcs:
+            func_doc = ast.get_docstring(func) is not None
+            checks.append(
+                {
+                    "check": f"docstring:{func.name}",
+                    "passed": func_doc,
+                    "detail": None if func_doc else f"missing docstring on {func.name}",
+                }
+            )
+            if not func_doc:
+                failed = True
+
+            annotated = _function_has_full_annotations(func)
+            checks.append(
+                {
+                    "check": f"annotations:{func.name}",
+                    "passed": annotated,
+                    "detail": None if annotated else f"missing type annotations on {func.name}",
+                }
+            )
+            if not annotated:
+                failed = True
+
+        # Wildcard imports
+        no_wildcards = not _has_wildcard_import(tree)
+        checks.append(
+            {
+                "check": "no_wildcard_imports",
+                "passed": no_wildcards,
+                "detail": None if no_wildcards else "wildcard import detected (from x import *)",
+            }
+        )
+        if not no_wildcards:
+            failed = True
+
+        # File length
+        line_count = len(source.splitlines())
+        under_limit = line_count <= _MAX_FILE_LINES
+        checks.append(
+            {
+                "check": "file_length",
+                "passed": under_limit,
+                "detail": None
+                if under_limit
+                else f"file has {line_count} lines (max {_MAX_FILE_LINES})",
+            }
+        )
+        if not under_limit:
+            failed = True
+
+        verdict = GateVerdict.FAIL if failed else GateVerdict.PASS
+        return GateResult(
+            gate_name=self.name,
+            verdict=verdict,
+            diagnostics={"checks": checks},
+        )

--- a/src/apprentice/gates/schema_compliance.py
+++ b/src/apprentice/gates/schema_compliance.py
@@ -1,3 +1,244 @@
 """Schema compliance gate — validates artifacts against no-magic-schema.yaml."""
 
 from __future__ import annotations
+
+import ast
+import csv
+import io
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+_SCHEMA_PATH = Path(__file__).parents[3] / "config" / "no-magic-schema.yaml"
+
+# Docstring section headers expected per the schema (Google-style lowercase)
+_DOCSTRING_SECTION_PATTERNS: dict[str, re.Pattern[str]] = {
+    "summary": re.compile(r"\S"),  # any non-blank content at the top counts
+    "args": re.compile(r"^\s*Args\s*:", re.MULTILINE),
+    "returns": re.compile(r"^\s*Returns\s*:", re.MULTILINE),
+    "complexity": re.compile(r"complexity", re.IGNORECASE),
+    "references": re.compile(r"^\s*References?\s*:", re.MULTILINE),
+}
+
+# Pattern for trace dict keys in instrumented source
+_TRACE_KEY_PATTERN = re.compile(r"""["'](\w+)["']\s*:""")
+
+
+def _load_schema(schema_path: Path) -> dict[str, Any]:
+    """Load and return the YAML schema as a dict."""
+    with schema_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise TypeError(f"schema at {schema_path} is not a YAML mapping")
+    return data
+
+
+def _check_implementation(source: str, required_sections: list[str]) -> list[dict[str, Any]]:
+    """Validate the module-level docstring has all required sections."""
+    checks: list[dict[str, Any]] = []
+    try:
+        tree = ast.parse(source)
+        docstring = ast.get_docstring(tree) or ""
+    except SyntaxError as exc:
+        return [{"check": "implementation_syntax", "passed": False, "detail": str(exc)}]
+
+    checks.append({"check": "implementation_syntax", "passed": True})
+
+    for section in required_sections:
+        pattern = _DOCSTRING_SECTION_PATTERNS.get(section)
+        if pattern is None:
+            # Fallback: look for the section name as a keyword
+            pattern = re.compile(re.escape(section), re.IGNORECASE)
+
+        found: bool = (
+            bool(docstring.strip()) if section == "summary" else bool(pattern.search(docstring))
+        )
+
+        checks.append(
+            {
+                "check": f"implementation_section:{section}",
+                "passed": found,
+                "detail": None if found else f"missing docstring section: {section}",
+            }
+        )
+    return checks
+
+
+def _check_instrumented(source: str, required_keys: list[str]) -> list[dict[str, Any]]:
+    """Check that the instrumented source references all required trace keys."""
+    checks: list[dict[str, Any]] = []
+    found_keys = set(_TRACE_KEY_PATTERN.findall(source))
+    for key in required_keys:
+        present = key in found_keys
+        checks.append(
+            {
+                "check": f"instrumented_trace_key:{key}",
+                "passed": present,
+                "detail": None if present else f"trace key '{key}' not found in instrumented file",
+            }
+        )
+    return checks
+
+
+def _check_anki(csv_content: str, required_types: list[str]) -> list[dict[str, Any]]:
+    """Check that the CSV contains at least one card of each required type."""
+    checks: list[dict[str, Any]] = []
+    reader = csv.reader(io.StringIO(csv_content))
+    rows = [row for row in reader if row]
+
+    # The schema requires front, back, tags, type — type is column index 3
+    found_types: set[str] = set()
+    for row in rows:
+        if len(row) >= 4:
+            found_types.add(row[3].strip().lower())
+
+    for card_type in required_types:
+        present = card_type.lower() in found_types
+        checks.append(
+            {
+                "check": f"anki_card_type:{card_type}",
+                "passed": present,
+                "detail": None if present else f"no anki card of type '{card_type}' found",
+            }
+        )
+    return checks
+
+
+def _check_manim(source: str) -> list[dict[str, Any]]:
+    """Check that the manim source defines at least one Scene subclass."""
+    checks: list[dict[str, Any]] = []
+    scene_class_pattern = re.compile(r"class\s+\w+\s*\([^)]*Scene[^)]*\)")
+    has_scene = bool(scene_class_pattern.search(source))
+    checks.append(
+        {
+            "check": "manim_scene_subclass",
+            "passed": has_scene,
+            "detail": None if has_scene else "no Scene subclass found in manim file",
+        }
+    )
+    return checks
+
+
+class SchemaComplianceGate:
+    """Validate all present artifacts conform to no-magic-schema.yaml conventions."""
+
+    name = "schema_compliance"
+    max_retries = 0
+    blocking = True
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        """Check each present artifact against the convention schema.
+
+        Args:
+            work_item: The work item being evaluated.
+            artifacts: Bundle of generated artifacts.
+
+        Returns:
+            GateResult with PASS or FAIL and per-artifact diagnostics.
+        """
+        schema = _load_schema(_SCHEMA_PATH)
+        algo_struct: dict[str, Any] = schema.get("algorithm_structure", {})
+        required_sections: list[str] = algo_struct.get("required_docstring_sections", [])
+
+        instrumentation: dict[str, Any] = schema.get("instrumentation", {})
+        required_trace_keys: list[str] = instrumentation.get("required_keys", [])
+
+        anki_schema: dict[str, Any] = schema.get("anki", {})
+        required_card_types: list[str] = anki_schema.get("card_types", [])
+
+        all_checks: list[dict[str, Any]] = []
+        failed = False
+
+        # Implementation
+        impl_path_str = artifacts.implementation_path
+        if impl_path_str:
+            impl_path = Path(impl_path_str)
+            if not impl_path.exists():
+                all_checks.append(
+                    {
+                        "check": "implementation_file_exists",
+                        "passed": False,
+                        "detail": f"not found: {impl_path_str}",
+                    }
+                )
+                failed = True
+            else:
+                impl_source = impl_path.read_text(encoding="utf-8")
+                impl_checks = _check_implementation(impl_source, required_sections)
+                all_checks.extend(impl_checks)
+                if any(not c["passed"] for c in impl_checks):
+                    failed = True
+
+        # Instrumented
+        instr_path_str = artifacts.instrumented_path
+        if instr_path_str:
+            instr_path = Path(instr_path_str)
+            if not instr_path.exists():
+                all_checks.append(
+                    {
+                        "check": "instrumented_file_exists",
+                        "passed": False,
+                        "detail": f"not found: {instr_path_str}",
+                    }
+                )
+                failed = True
+            else:
+                instr_source = instr_path.read_text(encoding="utf-8")
+                instr_checks = _check_instrumented(instr_source, required_trace_keys)
+                all_checks.extend(instr_checks)
+                if any(not c["passed"] for c in instr_checks):
+                    failed = True
+
+        # Anki CSV
+        anki_path_str = artifacts.anki_deck_path
+        if anki_path_str:
+            anki_path = Path(anki_path_str)
+            if not anki_path.exists():
+                all_checks.append(
+                    {
+                        "check": "anki_file_exists",
+                        "passed": False,
+                        "detail": f"not found: {anki_path_str}",
+                    }
+                )
+                failed = True
+            else:
+                anki_content = anki_path.read_text(encoding="utf-8")
+                anki_checks = _check_anki(anki_content, required_card_types)
+                all_checks.extend(anki_checks)
+                if any(not c["passed"] for c in anki_checks):
+                    failed = True
+
+        # Manim scene
+        manim_path_str = artifacts.manim_scene_path
+        if manim_path_str:
+            manim_path = Path(manim_path_str)
+            if not manim_path.exists():
+                all_checks.append(
+                    {
+                        "check": "manim_file_exists",
+                        "passed": False,
+                        "detail": f"not found: {manim_path_str}",
+                    }
+                )
+                failed = True
+            else:
+                manim_source = manim_path.read_text(encoding="utf-8")
+                manim_checks = _check_manim(manim_source)
+                all_checks.extend(manim_checks)
+                if any(not c["passed"] for c in manim_checks):
+                    failed = True
+
+        verdict = GateVerdict.FAIL if failed else GateVerdict.PASS
+        return GateResult(
+            gate_name=self.name,
+            verdict=verdict,
+            diagnostics={"checks": all_checks},
+        )

--- a/src/apprentice/prompts/assessment.yaml
+++ b/src/apprentice/prompts/assessment.yaml
@@ -1,0 +1,52 @@
+name: assessment
+version: "1.0.0"
+description: "Generates Anki flashcards as CSV for an algorithm implementation"
+
+system_prompt: |
+  You are an expert spaced-repetition card author for the no-magic educational project.
+  Your task is to generate Anki flashcards in CSV format covering an algorithm's
+  concepts, complexity, and implementation details.
+
+  Card authoring rules:
+  - Each card tests exactly one concept — never combine two questions.
+  - Fronts are concise questions or prompts (one sentence maximum).
+  - Backs give the minimal correct answer plus one clarifying detail.
+  - Use the algorithm's actual implementation for code-based cards.
+  - Complexity cards must use Big-O notation and explain best, average, and worst cases.
+  - Never include cards that test trivial facts (e.g., "What language is this written in?").
+  - Card types requested must all be covered with at least one card each.
+
+variables:
+  - algorithm_name
+  - implementation_code
+  - complexity_info
+  - card_types
+
+user_prompt_template: |
+  Generate Anki flashcards for the {{ algorithm_name }} algorithm.
+
+  Complexity information:
+  {{ complexity_info }}
+
+  Implementation (use for code-snippet cards):
+  ```python
+  {{ implementation_code }}
+  ```
+
+  Required card types (generate at least one card per type):
+  {% for card_type in card_types %}
+  - {{ card_type }}
+  {% endfor %}
+
+  Output format: CSV with a header row and one card per line.
+  Columns: `front`, `back`, `tags`
+
+  Rules:
+  1. `front`: A clear, single-concept question or prompt (no trailing punctuation required).
+  2. `back`: The minimal correct answer followed by one clarifying sentence.
+  3. `tags`: Space-separated tags — always include `{{ algorithm_name }}` and the card type slug.
+  4. Escape commas inside fields by wrapping the field in double quotes.
+  5. For code cards, wrap code snippets in backticks inside the field.
+  6. Generate between 5 and 15 cards total — quality over quantity.
+
+  Return **only** the CSV content (including the header row) inside a ```csv ... ``` fence.

--- a/src/apprentice/prompts/discovery.yaml
+++ b/src/apprentice/prompts/discovery.yaml
@@ -1,0 +1,37 @@
+name: discovery
+version: "1.0.0"
+description: "Suggests candidate algorithms for a given tier based on pedagogical value and prerequisites"
+
+system_prompt: |
+  You are a curriculum designer for the no-magic educational algorithms project.
+  Your role is to identify well-known, teachable algorithms that belong at a specific
+  learning tier. You prioritize:
+  - Clear pedagogical value — the algorithm teaches a transferable concept
+  - Appropriate complexity for the tier (1=beginner, 2=intermediate, 3=advanced, 4=expert)
+  - Prerequisites before variants (e.g., insertion sort before shell sort)
+  - Algorithms with clean, self-contained implementations (no heavy dependencies)
+
+  You never suggest algorithms already present in the catalog.
+
+variables:
+  - tier
+  - existing_algorithms
+  - limit
+
+user_prompt_template: |
+  Suggest {{ limit }} algorithm candidates suitable for tier {{ tier }} of an educational algorithms project.
+
+  Algorithms already in the catalog (do not repeat any of these):
+  {{ existing_algorithms }}
+
+  Requirements:
+  - Each candidate must be a well-known, self-contained algorithm.
+  - Prefer algorithms that build on tier {{ tier - 1 if tier > 1 else tier }} foundations.
+  - Choose algorithms with clear pedagogical value — they should teach a transferable concept.
+  - Avoid niche or highly domain-specific algorithms unless they are widely taught.
+
+  Return a JSON array where each element has exactly two keys:
+    "name": snake_case algorithm name (lowercase letters, digits, and underscores only, max 64 characters)
+    "rationale": one sentence explaining the pedagogical value at tier {{ tier }}
+
+  Return **only** the JSON array inside a ```json ... ``` fence.

--- a/src/apprentice/prompts/instrumentation.yaml
+++ b/src/apprentice/prompts/instrumentation.yaml
@@ -1,0 +1,43 @@
+name: instrumentation
+version: "1.0.0"
+description: "Adds trace hooks to an algorithm implementation for step-by-step observation"
+
+system_prompt: |
+  You are an expert in algorithm instrumentation for the no-magic educational project.
+  Your task is to add trace hooks to a clean algorithm implementation so that learners
+  can observe each meaningful step as it executes.
+
+  Instrumentation rules:
+  - Never alter the algorithm's correctness or time complexity class.
+  - Emit trace events by calling a provided `trace(event: str, **kwargs)` callback.
+  - Trace hooks must be placed at semantically meaningful points: comparisons, swaps,
+    assignments, recursive calls, and loop iterations that change state.
+  - Keep the original code structure intact — do not refactor or rename symbols.
+  - All trace calls must be guarded: only emit when a `trace` callable is provided.
+  - Preserve all existing type annotations and docstrings.
+
+variables:
+  - algorithm_name
+  - implementation_code
+  - trace_format
+
+user_prompt_template: |
+  Add trace hooks to the following {{ algorithm_name }} implementation.
+
+  Trace format specification:
+  {{ trace_format }}
+
+  Original implementation:
+  ```python
+  {{ implementation_code }}
+  ```
+
+  Requirements:
+  1. Accept an optional `trace` parameter (callable or None) on the main entry-point function.
+  2. Emit trace events using the format above at every meaningful algorithmic step.
+  3. Guard all trace calls: `if trace is not None: trace(...)`.
+  4. Do not change the algorithm's logic, complexity, or public API beyond adding the `trace` parameter.
+  5. Preserve all existing type annotations, docstrings, and the `if __name__ == "__main__":` block.
+  6. Add a docstring note explaining the trace parameter and the events it emits.
+
+  Return **only** the instrumented Python source code inside a ```python ... ``` fence.

--- a/src/apprentice/prompts/visualization.yaml
+++ b/src/apprentice/prompts/visualization.yaml
@@ -1,0 +1,52 @@
+name: visualization
+version: "1.0.0"
+description: "Generates Manim animation steps for an algorithm implementation"
+
+system_prompt: |
+  You are an expert Manim animator for the no-magic educational project.
+  Your task is to generate animation steps that visualize an algorithm's execution
+  using a provided Manim scaffold.
+
+  Animation rules:
+  - Each animation step must correspond to a semantically meaningful algorithmic event
+    (comparison, swap, assignment, recursive call, etc.).
+  - Use only Manim objects and methods present in the scaffold template.
+  - Animations must be deterministic and reproducible — no random elements.
+  - Keep scenes concise: prefer Transform and Indicate over constructing new objects.
+  - Include a brief text label for each major phase of the algorithm.
+  - Match the visual style of the reference animations provided.
+
+variables:
+  - algorithm_name
+  - implementation_code
+  - scaffold_template
+  - reference_animations
+
+user_prompt_template: |
+  Generate Manim animation steps for the {{ algorithm_name }} algorithm.
+
+  Algorithm implementation (use this as the authoritative reference for step ordering):
+  ```python
+  {{ implementation_code }}
+  ```
+
+  Manim scaffold template (fill in the `construct` method):
+  ```python
+  {{ scaffold_template }}
+  ```
+
+  Reference animations to match in style:
+  {% for ref in reference_animations %}
+  --- {{ ref.name }} ---
+  {{ ref.code }}
+  {% endfor %}
+
+  Requirements:
+  1. Fill in the `construct` method of the scaffold — do not change the class name or imports.
+  2. Animate every meaningful algorithmic step: comparisons, swaps, assignments, recursion.
+  3. Add a title and a brief label at the start of each algorithm phase.
+  4. Use `self.wait(0.5)` between major steps and `self.wait(1)` at the end.
+  5. Match the visual style (colors, object sizes, layout) of the reference animations.
+  6. Include a comment above each animation block explaining what algorithmic step it shows.
+
+  Return **only** the completed Python Manim source inside a ```python ... ``` fence.

--- a/src/apprentice/stages/assessment.py
+++ b/src/apprentice/stages/assessment.py
@@ -1,3 +1,295 @@
 """Assessment stage — Anki flashcard deck generation."""
 
 from __future__ import annotations
+
+import csv
+import io
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.budget import CostEstimate
+    from apprentice.models.work_item import PipelineContext, StageResult, WorkItem
+
+# Estimated total tokens for card generation (straightforward task)
+_TOTAL_TOKENS: int = 3_000
+
+# Hardcoded Sonnet rates (USD per token)
+_INPUT_RATE_USD: float = 3.0 / 1_000_000
+_OUTPUT_RATE_USD: float = 15.0 / 1_000_000
+
+# 60 % input / 40 % output split for estimates
+_INPUT_FRACTION: float = 0.6
+_OUTPUT_FRACTION: float = 0.4
+
+# Max tokens ceiling for provider call
+_MAX_TOKENS: int = 6_000
+
+# Expected CSV columns per schema
+_CSV_COLUMNS: tuple[str, ...] = ("front", "back", "tags", "type")
+_MIN_CARDS: int = 8
+_CARD_TYPES: tuple[str, ...] = ("concept", "complexity", "implementation", "comparison")
+
+
+class AssessmentStage:
+    """Generate Anki flashcard decks from algorithm implementations.
+
+    Attributes:
+        name: Stage identifier used by the pipeline.
+    """
+
+    name: str = "assessment"
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        """Return a pre-execution cost estimate.
+
+        Args:
+            work_item: The algorithm work item to estimate for.
+
+        Returns:
+            CostEstimate with token split and USD cost.
+        """
+        from apprentice.models.budget import CostEstimate
+
+        input_tokens = int(_TOTAL_TOKENS * _INPUT_FRACTION)
+        output_tokens = int(_TOTAL_TOKENS * _OUTPUT_FRACTION)
+        cost = input_tokens * _INPUT_RATE_USD + output_tokens * _OUTPUT_RATE_USD
+        return CostEstimate(
+            estimated_input_tokens=input_tokens,
+            estimated_output_tokens=output_tokens,
+            estimated_cost_usd=round(cost, 6),
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        """Generate, validate, and persist an Anki flashcard CSV.
+
+        Args:
+            work_item: Describes the algorithm to generate cards for.
+            context: Pipeline-wide configuration and budget state.
+
+        Returns:
+            StageResult with the anki_deck artifact path, token usage, cost,
+            and diagnostics.
+        """
+        from apprentice.models.work_item import StageResult
+
+        implementation_path = context.config.get("artifacts", {}).get("implementation", "")
+        source_code = _read_implementation(implementation_path)
+
+        prompt = _build_prompt(work_item, source_code)
+        completion = _generate(prompt, context)
+
+        csv_content = _extract_csv(completion.text)
+
+        diagnostics: list[dict[str, Any]] = []
+        validation_issues = _validate_csv(csv_content)
+        if validation_issues:
+            diagnostics.extend(
+                {"level": "warning", "message": issue} for issue in validation_issues
+            )
+
+        artifact_path = _write_artifact(work_item.algorithm_name, csv_content)
+        total_tokens = completion.input_tokens + completion.output_tokens
+        cost = (
+            completion.input_tokens * _INPUT_RATE_USD + completion.output_tokens * _OUTPUT_RATE_USD
+        )
+
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"anki_deck": artifact_path},
+            tokens_used=total_tokens,
+            cost_usd=round(cost, 6),
+            diagnostics=diagnostics,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal data class — avoids importing provider types at runtime
+# ---------------------------------------------------------------------------
+
+
+class _Completion:
+    """Thin holder for provider response data."""
+
+    __slots__ = ("input_tokens", "output_tokens", "text")
+
+    def __init__(self, text: str, input_tokens: int, output_tokens: int) -> None:
+        self.text = text
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _read_implementation(path: str) -> str:
+    """Read implementation source from disk.
+
+    Args:
+        path: Absolute path to the implementation file.
+
+    Returns:
+        File contents as a string, or empty string if path is empty or missing.
+    """
+    if not path:
+        return ""
+    p = Path(path)
+    if not p.exists():
+        return ""
+    return p.read_text(encoding="utf-8")
+
+
+def _build_prompt(work_item: WorkItem, source_code: str) -> str:
+    """Construct the LLM prompt for Anki card generation.
+
+    Args:
+        work_item: Algorithm metadata.
+        source_code: Implementation source to base cards on.
+
+    Returns:
+        Formatted prompt string.
+    """
+    source_section = (
+        f"\n\n## Implementation Reference\n\n```python\n{source_code}\n```"
+        if source_code
+        else "\n\n(No implementation provided — generate cards from general knowledge.)"
+    )
+
+    card_types_str = ", ".join(f"`{t}`" for t in _CARD_TYPES)
+
+    return (
+        f"Generate Anki flashcards for the **{work_item.algorithm_name}** algorithm "
+        f"(tier {work_item.tier}).\n"
+        f"{source_section}\n\n"
+        "## Requirements\n\n"
+        f"- Produce at least {_MIN_CARDS} cards total — at least 2 per type.\n"
+        f"- Card types: {card_types_str}.\n"
+        "  - `concept`: what the algorithm is and how it works conceptually.\n"
+        "  - `complexity`: time and space complexity with justification.\n"
+        "  - `implementation`: code-level details, edge cases, invariants.\n"
+        "  - `comparison`: how this algorithm compares to similar alternatives.\n"
+        "- Output format: CSV with a header row and one card per subsequent row.\n"
+        "- Columns (in this exact order): `front`, `back`, `tags`, `type`.\n"
+        "  - `front`: question or prompt (no commas — use semicolons if needed).\n"
+        "  - `back`: answer or explanation.\n"
+        "  - `tags`: space-separated tags (e.g. `algorithms sorting`).\n"
+        f"  - `type`: one of {card_types_str}.\n"
+        "- All fields must be non-empty.\n"
+        "- Wrap the CSV in a ```csv ... ``` fence.\n\n"
+        "Return **only** the CSV inside a ```csv ... ``` fence."
+    )
+
+
+def _generate(prompt: str, context: PipelineContext) -> _Completion:
+    """Invoke the configured provider to generate the flashcard CSV.
+
+    Args:
+        prompt: Fully constructed prompt string.
+        context: Pipeline context; reads ``config["provider"]`` for the provider instance.
+
+    Returns:
+        A _Completion with text and token counts.
+
+    Raises:
+        RuntimeError: If no provider is configured.
+    """
+    provider = context.config.get("provider")
+
+    if provider is not None and hasattr(provider, "complete"):
+        result = provider.complete(prompt, {}, _MAX_TOKENS)
+        return _Completion(
+            text=result.text,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+        )
+
+    raise RuntimeError(
+        "No provider configured. Set context.config['provider'] to a ProviderInterface instance."
+    )
+
+
+def _extract_csv(response: str) -> str:
+    """Extract CSV content from a markdown fenced block.
+
+    Tries ```csv first, then falls back to a generic ``` fence, then returns
+    the raw response if no fence is found.
+
+    Args:
+        response: Raw LLM response text.
+
+    Returns:
+        CSV content with surrounding whitespace stripped.
+    """
+    for fence_open in ("```csv", "```"):
+        start = response.find(fence_open)
+        if start == -1:
+            continue
+        code_start = start + len(fence_open)
+        end = response.find("```", code_start)
+        if end == -1:
+            return response[code_start:].strip()
+        return response[code_start:end].strip()
+
+    return response.strip()
+
+
+def _validate_csv(content: str) -> list[str]:
+    """Validate that CSV content meets the Anki schema requirements.
+
+    Args:
+        content: Raw CSV string to validate.
+
+    Returns:
+        List of human-readable issue descriptions. Empty list means valid.
+    """
+    issues: list[str] = []
+
+    if not content.strip():
+        issues.append("CSV content is empty")
+        return issues
+
+    try:
+        reader = csv.DictReader(io.StringIO(content))
+        if reader.fieldnames is None:
+            issues.append("CSV has no header row")
+            return issues
+
+        actual_fields = [f.strip() for f in reader.fieldnames]
+        missing = [col for col in _CSV_COLUMNS if col not in actual_fields]
+        if missing:
+            issues.append(f"CSV missing required columns: {missing}")
+
+        rows = list(reader)
+        if len(rows) < _MIN_CARDS:
+            issues.append(f"CSV has {len(rows)} cards; minimum is {_MIN_CARDS}")
+
+        for i, row in enumerate(rows, start=2):
+            for col in _CSV_COLUMNS:
+                val = (row.get(col) or "").strip()
+                if not val:
+                    issues.append(f"Row {i}: column '{col}' is empty")
+
+    except csv.Error as exc:
+        issues.append(f"CSV parse error: {exc}")
+
+    return issues
+
+
+def _write_artifact(algorithm_name: str, content: str) -> str:
+    """Write CSV content to a temp file and return its path string.
+
+    Args:
+        algorithm_name: Used as the filename stem.
+        content: CSV source to persist.
+
+    Returns:
+        Absolute path to the written file as a string.
+    """
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    dest = tmp_dir / f"{algorithm_name}_cards.csv"
+    dest.write_text(content, encoding="utf-8")
+    return str(dest)

--- a/src/apprentice/stages/discovery.py
+++ b/src/apprentice/stages/discovery.py
@@ -1,3 +1,394 @@
-"""Discovery stage — candidate algorithm ranking and selection."""
+"""Discovery stage — suggest candidate algorithms for a given tier."""
 
 from __future__ import annotations
+
+import json
+import re
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.budget import CostEstimate
+    from apprentice.models.work_item import PipelineContext, StageResult, WorkItem
+
+# Fixed token budget for the discovery stage — lightweight compared to implementation
+_TOTAL_TOKENS: int = 2_000
+
+# Hardcoded Sonnet rates (USD per token)
+_INPUT_RATE_USD: float = 3.0 / 1_000_000
+_OUTPUT_RATE_USD: float = 15.0 / 1_000_000
+
+# 60 % input / 40 % output split for estimates
+_INPUT_FRACTION: float = 0.6
+_OUTPUT_FRACTION: float = 0.4
+
+# Default catalog path relative to this file's package root
+_CATALOG_PATH: Path = Path(__file__).parent.parent.parent.parent / "config" / "catalog.toml"
+
+# Valid algorithm name pattern: lowercase alphanumeric + underscores, max 64 chars
+_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z0-9_]{1,64}$")
+
+# Default number of candidates to request per discovery run
+_DEFAULT_LIMIT: int = 5
+
+
+class DiscoveryStage:
+    """Suggest non-duplicate algorithm candidates for a given tier.
+
+    Attributes:
+        name: Stage identifier used by the pipeline.
+    """
+
+    name: str = "discovery"
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        """Return a pre-execution cost estimate for the discovery stage.
+
+        Args:
+            work_item: The work item triggering discovery (tier is read for context).
+
+        Returns:
+            CostEstimate with token split and USD cost.
+        """
+        from apprentice.models.budget import CostEstimate
+
+        input_tokens = int(_TOTAL_TOKENS * _INPUT_FRACTION)
+        output_tokens = int(_TOTAL_TOKENS * _OUTPUT_FRACTION)
+        cost = input_tokens * _INPUT_RATE_USD + output_tokens * _OUTPUT_RATE_USD
+        return CostEstimate(
+            estimated_input_tokens=input_tokens,
+            estimated_output_tokens=output_tokens,
+            estimated_cost_usd=round(cost, 6),
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        """Run algorithm discovery for the work item's tier.
+
+        Loads the catalog, asks the configured provider for candidate algorithm
+        names, deduplicates against existing entries, and writes a JSON artifact
+        listing accepted candidates with rationale.
+
+        Args:
+            work_item: Supplies the tier to target. ``algorithm_name`` and
+                       ``rationale`` are used as context hints for the LLM.
+            context: Pipeline-wide config including the provider instance and
+                     optional ``catalog_path`` override.
+
+        Returns:
+            StageResult with a ``"candidates"`` artifact path, token usage,
+            cost, and diagnostics for any rejected or invalid names.
+
+        Raises:
+            RuntimeError: If no provider is configured in ``context.config``.
+        """
+        from apprentice.models.work_item import StageResult
+
+        catalog_path = Path(context.config.get("catalog_path", str(_CATALOG_PATH)))
+        existing_names = _load_catalog_names(catalog_path)
+
+        limit: int = int(context.config.get("discovery_limit", _DEFAULT_LIMIT))
+        prompt = self._build_prompt(work_item, existing_names, limit)
+        completion = self._generate(prompt, context)
+
+        raw_candidates = _parse_candidates(completion.text)
+
+        diagnostics: list[dict[str, Any]] = []
+        accepted: list[dict[str, str]] = []
+
+        for entry in raw_candidates:
+            name = entry.get("name", "")
+            rationale = entry.get("rationale", "")
+
+            normalized = _normalize_name(name)
+            if not _NAME_PATTERN.match(normalized):
+                diagnostics.append(
+                    {
+                        "level": "warning",
+                        "message": "invalid algorithm name rejected",
+                        "name": name,
+                    }
+                )
+                continue
+
+            if _is_duplicate(normalized, existing_names):
+                diagnostics.append(
+                    {
+                        "level": "info",
+                        "message": "duplicate candidate filtered",
+                        "name": normalized,
+                    }
+                )
+                continue
+
+            accepted.append({"name": normalized, "rationale": rationale})
+
+        artifact_path = self._write_artifact(work_item.algorithm_name, accepted)
+        total_tokens = completion.input_tokens + completion.output_tokens
+        cost = (
+            completion.input_tokens * _INPUT_RATE_USD + completion.output_tokens * _OUTPUT_RATE_USD
+        )
+
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"candidates": artifact_path},
+            tokens_used=total_tokens,
+            cost_usd=round(cost, 6),
+            diagnostics=diagnostics,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_prompt(
+        self,
+        work_item: WorkItem,
+        existing_names: list[str],
+        limit: int,
+    ) -> str:
+        """Construct the discovery prompt.
+
+        Args:
+            work_item: Provides tier and optional context hints.
+            existing_names: Names already in the catalog (for exclusion).
+            limit: Maximum number of candidates to request.
+
+        Returns:
+            Formatted prompt string.
+        """
+        existing_section = ", ".join(existing_names) if existing_names else "none"
+        return (
+            f"Suggest {limit} algorithm candidates suitable for tier {work_item.tier} "
+            f"of an educational algorithms project.\n\n"
+            f"**Context hint:** {work_item.rationale or 'N/A'}\n\n"
+            f"**Already in catalog (do not repeat):** {existing_section}\n\n"
+            "## Requirements\n\n"
+            "- Each candidate must be a well-known, self-contained algorithm.\n"
+            "- Choose algorithms with clear pedagogical value at this tier.\n"
+            "- Prefer prerequisites before advanced variants.\n\n"
+            "Return a JSON array where each element has exactly two keys:\n"
+            '  "name": snake_case algorithm name (lowercase, underscores only)\n'
+            '  "rationale": one sentence explaining pedagogical value\n\n'
+            "Return **only** the JSON array inside a ```json ... ``` fence."
+        )
+
+    def _generate(self, prompt: str, context: PipelineContext) -> _Completion:
+        """Invoke the configured provider to generate candidate suggestions.
+
+        Args:
+            prompt: Fully constructed prompt string.
+            context: Pipeline context; reads ``config["provider"]``.
+
+        Returns:
+            A _Completion with text and token counts.
+
+        Raises:
+            RuntimeError: If no provider is configured.
+        """
+        provider = context.config.get("provider")
+
+        if provider is not None and hasattr(provider, "complete"):
+            result = provider.complete(prompt, {}, _TOTAL_TOKENS * 2)
+            return _Completion(
+                text=result.text,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+            )
+
+        raise RuntimeError(
+            "No provider configured. Set context.config['provider'] to a ProviderInterface instance."
+        )
+
+    def _write_artifact(self, context_name: str, candidates: list[dict[str, str]]) -> str:
+        """Persist the accepted candidates as a JSON file.
+
+        Args:
+            context_name: Used as a stem for the output filename.
+            candidates: List of accepted candidate dicts with name and rationale.
+
+        Returns:
+            Absolute path to the written JSON file as a string.
+        """
+        tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        dest = tmp_dir / f"{context_name}_discovery.json"
+        dest.write_text(json.dumps(candidates, indent=2), encoding="utf-8")
+        return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Internal data class
+# ---------------------------------------------------------------------------
+
+
+class _Completion:
+    """Thin holder for provider response data."""
+
+    __slots__ = ("input_tokens", "output_tokens", "text")
+
+    def __init__(self, text: str, input_tokens: int, output_tokens: int) -> None:
+        self.text = text
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Module-level pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_catalog_names(catalog_path: Path) -> list[str]:
+    """Load all algorithm names and aliases from the catalog TOML.
+
+    Args:
+        catalog_path: Absolute path to ``catalog.toml``.
+
+    Returns:
+        Flat list of normalized names and aliases found in the catalog.
+
+    Raises:
+        FileNotFoundError: If ``catalog_path`` does not exist.
+        ValueError: If the catalog is malformed (missing ``algorithms`` key).
+    """
+    if not catalog_path.exists():
+        raise FileNotFoundError(f"Catalog not found: {catalog_path}")
+
+    with catalog_path.open("rb") as fh:
+        data: Any = tomllib.load(fh)
+
+    algorithms: Any = data.get("algorithms", [])
+    if not isinstance(algorithms, list):
+        raise ValueError(f"Expected 'algorithms' to be a list in {catalog_path}")
+
+    names: list[str] = []
+    for entry in algorithms:
+        if not isinstance(entry, dict):
+            continue
+        raw_name = entry.get("name", "")
+        if isinstance(raw_name, str) and raw_name:
+            names.append(_normalize_name(raw_name))
+        aliases: Any = entry.get("aliases", [])
+        if isinstance(aliases, list):
+            for alias in aliases:
+                if isinstance(alias, str) and alias:
+                    names.append(_normalize_name(alias))
+
+    return names
+
+
+def _parse_candidates(response: str) -> list[dict[str, str]]:
+    """Extract the JSON candidate array from a fenced LLM response.
+
+    Args:
+        response: Raw LLM response text.
+
+    Returns:
+        List of candidate dicts. Each dict has at least a ``"name"`` key.
+        Returns an empty list if parsing fails.
+    """
+    fence_open = "```json"
+    fence_close = "```"
+
+    start = response.find(fence_open)
+    if start == -1:
+        json_text = response.strip()
+    else:
+        code_start = start + len(fence_open)
+        end = response.find(fence_close, code_start)
+        json_text = response[code_start:end].strip() if end != -1 else response[code_start:].strip()
+
+    try:
+        parsed: Any = json.loads(json_text)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    if not isinstance(parsed, list):
+        return []
+
+    result: list[dict[str, str]] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name", "")
+        rationale = item.get("rationale", "")
+        if isinstance(name, str) and name:
+            result.append({"name": name, "rationale": str(rationale)})
+
+    return result
+
+
+def _levenshtein_distance(s1: str, s2: str) -> int:
+    """Compute the Levenshtein edit distance between two strings.
+
+    Args:
+        s1: First string.
+        s2: Second string.
+
+    Returns:
+        Minimum number of single-character edits to transform s1 into s2.
+    """
+    m, n = len(s1), len(s2)
+    dp: list[list[int]] = [[0] * (n + 1) for _ in range(m + 1)]
+
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+
+    return dp[m][n]
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize an algorithm name for fuzzy comparison.
+
+    Lowercases, strips whitespace, and replaces hyphens and spaces with
+    underscores.
+
+    Args:
+        name: Raw algorithm name string.
+
+    Returns:
+        Normalized name safe for comparison and catalog insertion.
+    """
+    return name.lower().strip().replace("-", "_").replace(" ", "_")
+
+
+def _is_duplicate(
+    candidate: str,
+    existing: list[str],
+    threshold: float = 0.85,
+) -> bool:
+    """Check whether a candidate name is too similar to any existing name.
+
+    Uses normalized Levenshtein similarity:
+    ``similarity = 1 - distance / max(len(a), len(b))``.
+
+    Args:
+        candidate: Normalized candidate name.
+        existing: List of normalized existing names.
+        threshold: Similarity threshold at or above which names are considered
+                   duplicates. Defaults to 0.85.
+
+    Returns:
+        True if any existing name has similarity >= threshold.
+    """
+    norm_candidate = _normalize_name(candidate)
+    for name in existing:
+        norm_name = _normalize_name(name)
+        max_len = max(len(norm_candidate), len(norm_name))
+        if max_len == 0:
+            continue
+        distance = _levenshtein_distance(norm_candidate, norm_name)
+        similarity = 1.0 - distance / max_len
+        if similarity >= threshold:
+            return True
+    return False

--- a/src/apprentice/stages/instrumentation.py
+++ b/src/apprentice/stages/instrumentation.py
@@ -1,3 +1,247 @@
 """Instrumentation stage — adds trace hooks for step-by-step replay."""
 
 from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.budget import CostEstimate
+    from apprentice.models.work_item import PipelineContext, StageResult, WorkItem
+
+# Estimated total tokens for instrumentation (slightly less than implementation)
+_TOTAL_TOKENS: int = 4_000
+
+# Hardcoded Sonnet rates (USD per token)
+_INPUT_RATE_USD: float = 3.0 / 1_000_000
+_OUTPUT_RATE_USD: float = 15.0 / 1_000_000
+
+# 60 % input / 40 % output split for estimates
+_INPUT_FRACTION: float = 0.6
+_OUTPUT_FRACTION: float = 0.4
+
+# Max tokens ceiling for provider call
+_MAX_TOKENS: int = 8_000
+
+
+class InstrumentationStage:
+    """Add JSON trace hooks to an existing algorithm implementation.
+
+    Attributes:
+        name: Stage identifier used by the pipeline.
+    """
+
+    name: str = "instrumentation"
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        """Return a pre-execution cost estimate.
+
+        Args:
+            work_item: The algorithm work item to estimate for.
+
+        Returns:
+            CostEstimate with token split and USD cost.
+        """
+        from apprentice.models.budget import CostEstimate
+
+        input_tokens = int(_TOTAL_TOKENS * _INPUT_FRACTION)
+        output_tokens = int(_TOTAL_TOKENS * _OUTPUT_FRACTION)
+        cost = input_tokens * _INPUT_RATE_USD + output_tokens * _OUTPUT_RATE_USD
+        return CostEstimate(
+            estimated_input_tokens=input_tokens,
+            estimated_output_tokens=output_tokens,
+            estimated_cost_usd=round(cost, 6),
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        """Instrument an implementation with trace hooks and persist the result.
+
+        Args:
+            work_item: Describes the algorithm being instrumented.
+            context: Pipeline-wide configuration and budget state.
+
+        Returns:
+            StageResult with the instrumented artifact path, token usage, cost,
+            and diagnostics.
+        """
+        from apprentice.models.work_item import StageResult
+
+        implementation_path = context.config.get("artifacts", {}).get("implementation", "")
+        source_code = _read_implementation(implementation_path)
+
+        prompt = _build_prompt(work_item, source_code)
+        completion = _generate(prompt, context)
+
+        instrumented_code = _extract_code_block(completion.text)
+
+        diagnostics: list[dict[str, Any]] = []
+        if not instrumented_code.strip():
+            diagnostics.append(
+                {
+                    "level": "warning",
+                    "message": "extracted instrumented code is empty; using raw response",
+                }
+            )
+            instrumented_code = completion.text
+
+        artifact_path = _write_artifact(work_item.algorithm_name, instrumented_code)
+        total_tokens = completion.input_tokens + completion.output_tokens
+        cost = (
+            completion.input_tokens * _INPUT_RATE_USD + completion.output_tokens * _OUTPUT_RATE_USD
+        )
+
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"instrumented": artifact_path},
+            tokens_used=total_tokens,
+            cost_usd=round(cost, 6),
+            diagnostics=diagnostics,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal data class — avoids importing provider types at runtime
+# ---------------------------------------------------------------------------
+
+
+class _Completion:
+    """Thin holder for provider response data."""
+
+    __slots__ = ("input_tokens", "output_tokens", "text")
+
+    def __init__(self, text: str, input_tokens: int, output_tokens: int) -> None:
+        self.text = text
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _read_implementation(path: str) -> str:
+    """Read implementation source from disk.
+
+    Args:
+        path: Absolute path to the implementation file.
+
+    Returns:
+        File contents as a string, or empty string if path is empty or missing.
+    """
+    if not path:
+        return ""
+    p = Path(path)
+    if not p.exists():
+        return ""
+    return p.read_text(encoding="utf-8")
+
+
+def _build_prompt(work_item: WorkItem, source_code: str) -> str:
+    """Construct the LLM prompt for instrumentation.
+
+    Args:
+        work_item: Algorithm metadata.
+        source_code: Existing implementation to instrument.
+
+    Returns:
+        Formatted prompt string.
+    """
+    source_section = (
+        f"\n\n## Existing Implementation\n\n```python\n{source_code}\n```"
+        if source_code
+        else "\n\n(No existing implementation provided — generate from scratch with tracing.)"
+    )
+
+    return (
+        f"Instrument the **{work_item.algorithm_name}** algorithm implementation "
+        f"with JSON structured trace hooks.\n"
+        f"{source_section}\n\n"
+        "## Requirements\n\n"
+        "- At every significant decision point (comparisons, swaps, splits, merges, "
+        "boundary checks), append a trace entry to a module-level `_trace` list.\n"
+        "- Each trace entry must be a dict with exactly these keys:\n"
+        '  - `"step"`: integer counter, starting at 1, incremented for every entry.\n'
+        '  - `"operation"`: short string describing the operation (e.g. `"compare"`, '
+        '`"swap"`, `"split"`, `"merge"`).\n'
+        '  - `"state"`: dict capturing the relevant local state at that point '
+        "(e.g. indices, values, partial results).\n"
+        "- At the end of the main algorithm function, print `_trace` as JSON using "
+        "`import json; print(json.dumps(_trace, indent=2))`.\n"
+        "- Reset `_trace = []` at the start of each top-level algorithm call so the "
+        "function is reentrant.\n"
+        "- Preserve all original logic, type annotations, and docstrings.\n"
+        "- Standard library only — zero third-party imports.\n\n"
+        "Return **only** the instrumented Python source code inside a ```python ... ``` fence."
+    )
+
+
+def _generate(prompt: str, context: PipelineContext) -> _Completion:
+    """Invoke the configured provider to generate the instrumented code.
+
+    Args:
+        prompt: Fully constructed prompt string.
+        context: Pipeline context; reads ``config["provider"]`` for the provider instance.
+
+    Returns:
+        A _Completion with text and token counts.
+
+    Raises:
+        RuntimeError: If no provider is configured.
+    """
+    provider = context.config.get("provider")
+
+    if provider is not None and hasattr(provider, "complete"):
+        result = provider.complete(prompt, {}, _MAX_TOKENS)
+        return _Completion(
+            text=result.text,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+        )
+
+    raise RuntimeError(
+        "No provider configured. Set context.config['provider'] to a ProviderInterface instance."
+    )
+
+
+def _extract_code_block(response: str) -> str:
+    """Extract Python source from a markdown fenced code block.
+
+    Args:
+        response: Raw LLM response text.
+
+    Returns:
+        Python source with surrounding whitespace stripped. If no fence is
+        found the full response is returned unchanged.
+    """
+    fence_open = "```python"
+    fence_close = "```"
+
+    start = response.find(fence_open)
+    if start == -1:
+        return response.strip()
+
+    code_start = start + len(fence_open)
+    end = response.find(fence_close, code_start)
+    if end == -1:
+        return response[code_start:].strip()
+
+    return response[code_start:end].strip()
+
+
+def _write_artifact(algorithm_name: str, code: str) -> str:
+    """Write instrumented code to a temp file and return its path string.
+
+    Args:
+        algorithm_name: Used as the filename stem.
+        code: Python source to persist.
+
+    Returns:
+        Absolute path to the written file as a string.
+    """
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    dest = tmp_dir / f"{algorithm_name}_instrumented.py"
+    dest.write_text(code, encoding="utf-8")
+    return str(dest)

--- a/src/apprentice/stages/validation.py
+++ b/src/apprentice/stages/validation.py
@@ -1,3 +1,482 @@
 """Validation stage — correctness, render, and format verification."""
 
 from __future__ import annotations
+
+import ast
+import csv
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apprentice.models.budget import CostEstimate
+    from apprentice.models.work_item import PipelineContext, StageResult, WorkItem
+
+# Fixed overhead token estimate (no LLM calls, just accounting for context overhead)
+_OVERHEAD_TOKENS: int = 500
+
+# Valid Anki card type values per no-magic-schema.yaml
+_VALID_CARD_TYPES: frozenset[str] = frozenset(
+    {"concept", "complexity", "implementation", "comparison"}
+)
+
+# Minimum rows required in CSV (header + 3 data rows)
+_CSV_MIN_ROWS: int = 4
+
+# Expected field count per CSV row
+_CSV_FIELD_COUNT: int = 4
+
+# Compiled regex patterns for trace key detection
+_TRACE_KEY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r'["\']step["\']'),
+    re.compile(r'["\']operation["\']'),
+    re.compile(r'["\']state["\']'),
+)
+
+
+class ValidationStage:
+    """Run local checks against all generated artifacts.
+
+    No LLM calls are made. All checks are purely local: subprocess execution,
+    AST parsing, and file content inspection.
+
+    Attributes:
+        name: Stage identifier used by the pipeline.
+    """
+
+    name: str = "validation"
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        """Return a fixed overhead estimate — validation makes no LLM calls.
+
+        Args:
+            work_item: The algorithm work item (unused; included for interface conformance).
+
+        Returns:
+            CostEstimate with ~500 tokens overhead and zero USD cost.
+        """
+        from apprentice.models.budget import CostEstimate
+
+        return CostEstimate(
+            estimated_input_tokens=_OVERHEAD_TOKENS,
+            estimated_output_tokens=0,
+            estimated_cost_usd=0.0,
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        """Run all validation checks and return a StageResult with a JSON report.
+
+        Checks performed:
+        - Correctness: execute the implementation file and verify exit code 0.
+        - Complexity documentation: parse implementation AST and verify docstring
+          contains a Complexity section.
+        - Manim render (light): AST-parse the scene file for structural requirements.
+        - Anki format: verify CSV structure and card type values.
+        - Trace format: search instrumented file for required trace keys.
+
+        Args:
+            work_item: The algorithm work item being validated.
+            context: Pipeline-wide configuration; reads ``config["artifacts"]``.
+
+        Returns:
+            StageResult with ``validation_report`` artifact path, full diagnostics,
+            zero tokens used, and zero USD cost.
+        """
+        from apprentice.models.work_item import StageResult
+
+        artifacts_cfg: dict[str, str] = {}
+        raw = context.config.get("artifacts", {})
+        if isinstance(raw, dict):
+            artifacts_cfg = {str(k): str(v) for k, v in raw.items()}
+
+        impl_path = artifacts_cfg.get("implementation")
+        instrumented_path = artifacts_cfg.get("instrumented")
+        manim_path = artifacts_cfg.get("manim_scene")
+        anki_path = artifacts_cfg.get("anki_deck")
+
+        diagnostics: list[dict[str, Any]] = [
+            _check_correctness(impl_path),
+            _check_complexity_docs(impl_path),
+            _check_manim_structure(manim_path),
+            _check_anki_format(anki_path),
+            _check_trace_format(instrumented_path),
+        ]
+
+        report_path = _write_report(work_item.algorithm_name, diagnostics)
+
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"validation_report": report_path},
+            tokens_used=0,
+            cost_usd=0.0,
+            diagnostics=diagnostics,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check implementations (pure module-level functions)
+# ---------------------------------------------------------------------------
+
+
+def _check_correctness(path: str | None) -> dict[str, Any]:
+    """Execute the implementation file and check for exit code 0.
+
+    Args:
+        path: Absolute path to the implementation .py file, or None if absent.
+
+    Returns:
+        Diagnostic dict with ``check``, ``passed``, and ``details`` keys.
+    """
+    check_name = "correctness"
+
+    if path is None or not Path(path).exists():
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "implementation file not found",
+            "path": path,
+        }
+
+    result = subprocess.run(
+        [sys.executable, path],
+        capture_output=True,
+        timeout=10,
+        text=True,
+    )
+
+    passed = result.returncode == 0
+    return {
+        "check": check_name,
+        "passed": passed,
+        "details": "exit code 0" if passed else f"exit code {result.returncode}",
+        "stderr": result.stderr.strip() if result.stderr else None,
+        "path": path,
+    }
+
+
+def _check_complexity_docs(path: str | None) -> dict[str, Any]:
+    """Verify the main function's docstring contains a Complexity section.
+
+    Searches for "complexity", "time:", "space:", or "O(" (case-insensitive)
+    in the first function-level docstring found in the module.
+
+    Args:
+        path: Absolute path to the implementation .py file, or None if absent.
+
+    Returns:
+        Diagnostic dict with ``check``, ``passed``, and ``details`` keys.
+    """
+    check_name = "complexity_documentation"
+
+    if path is None or not Path(path).exists():
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "implementation file not found",
+            "path": path,
+        }
+
+    source = Path(path).read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"syntax error: {exc}",
+            "path": path,
+        }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            docstring = ast.get_docstring(node) or ""
+            lower = docstring.lower()
+            if "complexity" in lower or "time:" in lower or "space:" in lower or "o(" in lower:
+                return {
+                    "check": check_name,
+                    "passed": True,
+                    "details": f"complexity section found in '{node.name}'",
+                    "path": path,
+                }
+
+    return {
+        "check": check_name,
+        "passed": False,
+        "details": "no function docstring with complexity section found",
+        "path": path,
+    }
+
+
+def _check_manim_structure(path: str | None) -> dict[str, Any]:
+    """AST-parse the Manim scene file and verify structural requirements.
+
+    Checks:
+    - No syntax errors.
+    - At least one import from manim.
+    - At least one class with ``Scene`` in its bases.
+    - That class defines a ``construct`` method.
+
+    Args:
+        path: Absolute path to the Manim scene .py file, or None if absent.
+
+    Returns:
+        Diagnostic dict with ``check``, ``passed``, and ``details`` keys.
+    """
+    check_name = "manim_structure"
+
+    if path is None or not Path(path).exists():
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "manim scene file not found",
+            "path": path,
+        }
+
+    source = Path(path).read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"syntax error: {exc}",
+            "path": path,
+        }
+
+    if not _has_manim_import(tree):
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "no import from manim found",
+            "path": path,
+        }
+
+    scene_class = _find_scene_class(tree)
+    if scene_class is None:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "no class with Scene in bases found",
+            "path": path,
+        }
+
+    has_construct = any(
+        isinstance(n, ast.FunctionDef) and n.name == "construct"
+        for n in ast.walk(scene_class)
+        if n is not scene_class
+    )
+    if not has_construct:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"Scene class '{scene_class.name}' has no construct method",
+            "path": path,
+        }
+
+    return {
+        "check": check_name,
+        "passed": True,
+        "details": f"scene class '{scene_class.name}' with construct method found",
+        "path": path,
+    }
+
+
+def _check_anki_format(path: str | None) -> dict[str, Any]:
+    """Verify CSV structure: row count, field count, and valid card types.
+
+    Args:
+        path: Absolute path to the Anki CSV file, or None if absent.
+
+    Returns:
+        Diagnostic dict with ``check``, ``passed``, and ``details`` keys.
+    """
+    check_name = "anki_format"
+
+    if path is None or not Path(path).exists():
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "anki CSV file not found",
+            "path": path,
+        }
+
+    text = Path(path).read_text(encoding="utf-8")
+    reader = csv.reader(text.splitlines())
+    rows = list(reader)
+
+    if len(rows) < _CSV_MIN_ROWS:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": (
+                f"expected at least {_CSV_MIN_ROWS} rows (header + 3 data), got {len(rows)}"
+            ),
+            "path": path,
+        }
+
+    malformed = [i for i, row in enumerate(rows) if len(row) != _CSV_FIELD_COUNT]
+    if malformed:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"rows with wrong field count (expected {_CSV_FIELD_COUNT}): {malformed}",
+            "path": path,
+        }
+
+    header = [h.strip().lower() for h in rows[0]]
+    if "type" not in header:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "header row missing 'type' column",
+            "path": path,
+        }
+
+    type_col = header.index("type")
+    invalid_types = [
+        row[type_col].strip() for row in rows[1:] if row[type_col].strip() not in _VALID_CARD_TYPES
+    ]
+    if invalid_types:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"invalid card type values: {invalid_types}",
+            "path": path,
+        }
+
+    return {
+        "check": check_name,
+        "passed": True,
+        "details": f"{len(rows) - 1} data rows, all types valid",
+        "path": path,
+    }
+
+
+def _check_trace_format(path: str | None) -> dict[str, Any]:
+    """Search the instrumented file source for required trace keys.
+
+    Looks for string literals 'step', 'operation', and 'state' used as dict
+    keys (regex patterns against raw source).
+
+    Args:
+        path: Absolute path to the instrumented .py file, or None if absent.
+
+    Returns:
+        Diagnostic dict with ``check``, ``passed``, and ``details`` keys.
+    """
+    check_name = "trace_format"
+
+    if path is None or not Path(path).exists():
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": "instrumented file not found",
+            "path": path,
+        }
+
+    source = Path(path).read_text(encoding="utf-8")
+    missing = [pat.pattern for pat in _TRACE_KEY_PATTERNS if not pat.search(source)]
+
+    if missing:
+        return {
+            "check": check_name,
+            "passed": False,
+            "details": f"missing trace key patterns: {missing}",
+            "path": path,
+        }
+
+    return {
+        "check": check_name,
+        "passed": True,
+        "details": "all required trace keys (step, operation, state) found",
+        "path": path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report writer
+# ---------------------------------------------------------------------------
+
+
+def _write_report(algorithm_name: str, diagnostics: list[dict[str, Any]]) -> str:
+    """Serialize diagnostics to a JSON file in the temp artifacts directory.
+
+    Args:
+        algorithm_name: Used as the report filename stem.
+        diagnostics: List of check result dicts.
+
+    Returns:
+        Absolute path to the written JSON report as a string.
+    """
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    dest = tmp_dir / f"{algorithm_name}_validation_report.json"
+    dest.write_text(
+        json.dumps({"diagnostics": diagnostics}, indent=2),
+        encoding="utf-8",
+    )
+    return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_manim_import(tree: ast.Module) -> bool:
+    """Return True if the module imports anything from manim.
+
+    Args:
+        tree: Parsed AST of the module.
+
+    Returns:
+        True when at least one ``import manim`` or ``from manim`` node exists.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "manim" or alias.name.startswith("manim."):
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "manim" or module.startswith("manim."):
+                return True
+    return False
+
+
+def _find_scene_class(tree: ast.Module) -> ast.ClassDef | None:
+    """Return the first class definition that has ``Scene`` in its base names.
+
+    Args:
+        tree: Parsed AST of the module.
+
+    Returns:
+        The matching ClassDef node, or None if not found.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for base in node.bases:
+                base_name = _extract_name(base)
+                if base_name is not None and "Scene" in base_name:
+                    return node
+    return None
+
+
+def _extract_name(node: ast.expr) -> str | None:
+    """Extract a name string from a Name or Attribute AST node.
+
+    Args:
+        node: An expression node (typically a base class reference).
+
+    Returns:
+        The identifier string, or None if the node is neither Name nor Attribute.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None

--- a/src/apprentice/stages/visualization.py
+++ b/src/apprentice/stages/visualization.py
@@ -1,3 +1,330 @@
 """Visualization stage — Manim scene generation from scaffold templates."""
 
 from __future__ import annotations
+
+import re
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apprentice.models.budget import CostEstimate
+    from apprentice.models.work_item import PipelineContext, StageResult, WorkItem
+
+# Fixed token budget for Manim code generation (complex output)
+_TOTAL_TOKENS: int = 6_000
+
+# Hardcoded Sonnet rates (USD per token) — mirrors implementation.py
+_INPUT_RATE_USD: float = 3.0 / 1_000_000
+_OUTPUT_RATE_USD: float = 15.0 / 1_000_000
+
+# 60 % input / 40 % output split for estimates
+_INPUT_FRACTION: float = 0.6
+_OUTPUT_FRACTION: float = 0.4
+
+# Path to the Manim scaffold template, relative to this file's package root
+_TEMPLATE_NAME: str = "manim_scene.py.j2"
+
+
+class VisualizationStage:
+    """Generate a Manim scene that visualizes an algorithm's key operations.
+
+    Attributes:
+        name: Stage identifier used by the pipeline.
+    """
+
+    name: str = "visualization"
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        """Return a pre-execution cost estimate for Manim scene generation.
+
+        Args:
+            work_item: The algorithm work item to estimate for.
+
+        Returns:
+            CostEstimate with token split and USD cost.
+        """
+        from apprentice.models.budget import CostEstimate
+
+        input_tokens = int(_TOTAL_TOKENS * _INPUT_FRACTION)
+        output_tokens = int(_TOTAL_TOKENS * _OUTPUT_FRACTION)
+        cost = input_tokens * _INPUT_RATE_USD + output_tokens * _OUTPUT_RATE_USD
+        return CostEstimate(
+            estimated_input_tokens=input_tokens,
+            estimated_output_tokens=output_tokens,
+            estimated_cost_usd=round(cost, 6),
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        """Generate a complete Manim scene for the algorithm.
+
+        Reads the implementation artifact from context, prompts the LLM for
+        animation steps only, renders those into the scaffold template, and
+        writes the scene file to a temp directory.
+
+        Args:
+            work_item: Describes the algorithm to visualize.
+            context: Pipeline-wide configuration and budget state.
+
+        Returns:
+            StageResult with the manim_scene artifact path, token usage, cost,
+            and diagnostics.
+        """
+        from apprentice.models.work_item import StageResult
+
+        implementation_code = self._load_implementation(context)
+        template_text = self._load_template(context)
+        prompt = self._build_prompt(work_item, implementation_code, template_text)
+        completion = self._generate(prompt, context)
+
+        animation_steps = _extract_animation_steps(completion.text)
+        class_name = _to_pascal_case(work_item.algorithm_name)
+
+        scene_source = _render_template(
+            template_text=template_text,
+            algorithm_name=work_item.algorithm_name,
+            class_name=class_name,
+            animation_steps=animation_steps,
+        )
+
+        artifact_path = self._write_artifact(work_item.algorithm_name, scene_source)
+        total_tokens = completion.input_tokens + completion.output_tokens
+        cost = (
+            completion.input_tokens * _INPUT_RATE_USD + completion.output_tokens * _OUTPUT_RATE_USD
+        )
+
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"manim_scene": artifact_path},
+            tokens_used=total_tokens,
+            cost_usd=round(cost, 6),
+            diagnostics=[],
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_implementation(self, context: PipelineContext) -> str:
+        """Read the implementation artifact path from context config.
+
+        Args:
+            context: Pipeline context; reads ``config["implementation_artifact"]``.
+
+        Returns:
+            File contents if the path is present and readable, else empty string.
+        """
+        path_str = context.config.get("implementation_artifact", "")
+        if not path_str:
+            return ""
+        path = Path(str(path_str))
+        if not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8")
+
+    def _load_template(self, context: PipelineContext) -> str:
+        """Locate and read the Manim scaffold template.
+
+        Resolution order:
+        1. ``context.config["template_dir"]`` / manim_scene.py.j2
+        2. ``<package_root>/../../config/templates/`` / manim_scene.py.j2
+
+        Args:
+            context: Pipeline context; reads ``config["template_dir"]`` if set.
+
+        Returns:
+            Raw Jinja2 template text.
+
+        Raises:
+            FileNotFoundError: If the template cannot be found in either location.
+        """
+        candidates: list[Path] = []
+
+        template_dir = context.config.get("template_dir", "")
+        if template_dir:
+            candidates.append(Path(str(template_dir)) / _TEMPLATE_NAME)
+
+        # Derive from this file's location: stages/ → apprentice/ → src/ → project root
+        package_root = Path(__file__).parent.parent.parent.parent
+        candidates.append(package_root / "config" / "templates" / _TEMPLATE_NAME)
+
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate.read_text(encoding="utf-8")
+
+        raise FileNotFoundError(
+            f"Manim scaffold template not found. Searched: {[str(c) for c in candidates]}"
+        )
+
+    def _build_prompt(
+        self,
+        work_item: WorkItem,
+        implementation_code: str,
+        template_text: str,
+    ) -> str:
+        """Construct the LLM prompt requesting only animation_steps content.
+
+        Args:
+            work_item: Algorithm metadata.
+            implementation_code: Existing Python implementation for context.
+            template_text: The scaffold template so the LLM sees the structure.
+
+        Returns:
+            Formatted prompt string.
+        """
+        impl_section = ""
+        if implementation_code:
+            impl_section = (
+                f"\n\n## Existing Implementation\n\n```python\n{implementation_code}\n```"
+            )
+
+        return (
+            f"Generate Manim animation steps for the **{work_item.algorithm_name}** algorithm.\n\n"
+            "## Scaffold Template\n\n"
+            f"```python\n{template_text}\n```\n"
+            f"{impl_section}\n\n"
+            "## Requirements\n\n"
+            "- Produce ONLY the code that goes inside `construct()`, replacing "
+            "`{{ animation_steps }}`.\n"
+            "- Visualize the algorithm's key operations: comparisons, swaps, traversals, "
+            "insertions, or merges as appropriate.\n"
+            "- Use only basic Manim objects: Text, Square, Circle, Arrow, VGroup, "
+            "MathTex, DecimalNumber, Line, Dot.\n"
+            "- Use the color constants already defined on the class: "
+            "self.HIGHLIGHT_COLOR, self.COMPARE_COLOR, self.SWAP_COLOR, self.DONE_COLOR.\n"
+            "- Keep each animation step self-contained; use self.play() and self.wait().\n"
+            "- No imports — they are already provided by the scaffold.\n"
+            "- The code must be indented to match the 8-space depth inside construct().\n\n"
+            "Return **only** the animation steps inside a ```python ... ``` fence."
+        )
+
+    def _generate(self, prompt: str, context: PipelineContext) -> _Completion:
+        """Invoke the configured provider to generate animation steps.
+
+        Args:
+            prompt: Fully constructed prompt string.
+            context: Pipeline context; reads ``config["provider"]`` for the provider.
+
+        Returns:
+            A _Completion with text and token counts.
+
+        Raises:
+            RuntimeError: If no provider is configured.
+        """
+        provider = context.config.get("provider")
+        max_tokens = _TOTAL_TOKENS * 2
+
+        if provider is not None and hasattr(provider, "complete"):
+            result = provider.complete(prompt, {}, max_tokens)
+            return _Completion(
+                text=result.text,
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+            )
+
+        raise RuntimeError(
+            "No provider configured. Set context.config['provider'] to a ProviderInterface instance."
+        )
+
+    def _write_artifact(self, algorithm_name: str, scene_source: str) -> str:
+        """Write the rendered Manim scene to a temp file.
+
+        Args:
+            algorithm_name: Used as the filename stem.
+            scene_source: Complete Python source for the Manim scene.
+
+        Returns:
+            Absolute path to the written file as a string.
+        """
+        tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        dest = tmp_dir / f"{algorithm_name}_scene.py"
+        dest.write_text(scene_source, encoding="utf-8")
+        return str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Internal data class — avoids importing provider types at runtime
+# ---------------------------------------------------------------------------
+
+
+class _Completion:
+    """Thin holder for provider response data."""
+
+    __slots__ = ("input_tokens", "output_tokens", "text")
+
+    def __init__(self, text: str, input_tokens: int, output_tokens: int) -> None:
+        self.text = text
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _extract_animation_steps(response: str) -> str:
+    """Extract animation steps from a markdown fenced code block.
+
+    Args:
+        response: Raw LLM response text.
+
+    Returns:
+        Animation step code with surrounding whitespace stripped. If no fence
+        is found the full response is returned unchanged.
+    """
+    fence_open = "```python"
+    fence_close = "```"
+
+    start = response.find(fence_open)
+    if start == -1:
+        return response.strip()
+
+    code_start = start + len(fence_open)
+    end = response.find(fence_close, code_start)
+    if end == -1:
+        return response[code_start:].strip()
+
+    return response[code_start:end].strip()
+
+
+def _to_pascal_case(name: str) -> str:
+    """Convert a snake_case or space-separated algorithm name to PascalCase.
+
+    Args:
+        name: Algorithm name, e.g. ``"quick_sort"`` or ``"merge sort"``.
+
+    Returns:
+        PascalCase string, e.g. ``"QuickSort"``.
+    """
+    parts = re.split(r"[\s_\-]+", name)
+    return "".join(part.capitalize() for part in parts if part)
+
+
+def _render_template(
+    template_text: str,
+    algorithm_name: str,
+    class_name: str,
+    animation_steps: str,
+) -> str:
+    """Render the Jinja2 scaffold template with the provided variables.
+
+    Args:
+        template_text: Raw Jinja2 template source.
+        algorithm_name: Human-readable algorithm name for the title.
+        class_name: PascalCase class name for the scene class.
+        animation_steps: LLM-generated Manim code for construct().
+
+    Returns:
+        Fully rendered Python source string.
+    """
+    from jinja2 import Environment, StrictUndefined
+
+    env = Environment(undefined=StrictUndefined, keep_trailing_newline=True)
+    tmpl = env.from_string(template_text)
+    return tmpl.render(
+        algorithm_name=algorithm_name,
+        class_name=class_name,
+        animation_steps=animation_steps,
+    )

--- a/tests/test_discovery_stage.py
+++ b/tests/test_discovery_stage.py
@@ -1,0 +1,68 @@
+"""Tests for the discovery stage."""
+
+from __future__ import annotations
+
+from apprentice.stages.discovery import (
+    DiscoveryStage,
+    _is_duplicate,
+    _levenshtein_distance,
+    _normalize_name,
+)
+
+
+class TestNormalizeName:
+    def test_lowercase(self) -> None:
+        assert _normalize_name("QuickSort") == "quicksort"
+
+    def test_spaces_to_underscores(self) -> None:
+        assert _normalize_name("bubble sort") == "bubble_sort"
+
+    def test_hyphens_to_underscores(self) -> None:
+        assert _normalize_name("merge-sort") == "merge_sort"
+
+    def test_strips_whitespace(self) -> None:
+        assert _normalize_name("  dijkstra  ") == "dijkstra"
+
+
+class TestLevenshteinDistance:
+    def test_identical(self) -> None:
+        assert _levenshtein_distance("abc", "abc") == 0
+
+    def test_single_edit(self) -> None:
+        assert _levenshtein_distance("abc", "ab") == 1
+
+    def test_empty(self) -> None:
+        assert _levenshtein_distance("", "abc") == 3
+        assert _levenshtein_distance("abc", "") == 3
+
+    def test_completely_different(self) -> None:
+        assert _levenshtein_distance("abc", "xyz") == 3
+
+
+class TestIsDuplicate:
+    def test_exact_match(self) -> None:
+        assert _is_duplicate("quicksort", ["quicksort", "bubblesort"])
+
+    def test_high_similarity(self) -> None:
+        assert _is_duplicate("quick_sort", ["quicksort"])
+
+    def test_no_match(self) -> None:
+        assert not _is_duplicate("dijkstra", ["quicksort", "bubblesort"])
+
+    def test_alias_match(self) -> None:
+        assert _is_duplicate("bubblesort", ["bubble_sort"])
+
+
+class TestDiscoveryStage:
+    def test_name(self) -> None:
+        stage = DiscoveryStage()
+        assert stage.name == "discovery"
+
+    def test_estimate_cost(self) -> None:
+        from apprentice.models.work_item import WorkItem
+
+        stage = DiscoveryStage()
+        item = WorkItem(id="t", algorithm_name="discovery", tier=2)
+        estimate = stage.estimate_cost(item)
+        assert estimate.estimated_input_tokens > 0
+        assert estimate.estimated_cost_usd > 0

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,161 @@
+"""Tests for quality gates."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+from apprentice.gates.consistency import ConsistencyGate
+from apprentice.gates.correctness import CorrectnessGate
+from apprentice.gates.lint import LintGate
+from apprentice.gates.schema_compliance import SchemaComplianceGate
+from apprentice.models.artifact import ArtifactBundle
+from apprentice.models.work_item import GateVerdict, WorkItem
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_bundle(**kwargs: str) -> ArtifactBundle:
+    return ArtifactBundle(id="test", work_item_id="test", **kwargs)
+
+
+def _make_item(name: str = "quicksort") -> WorkItem:
+    return WorkItem(id="test", algorithm_name=name, tier=2)
+
+
+_GOOD_CODE = textwrap.dedent('''\
+    """Quicksort — divide and conquer sorting.
+
+    Complexity:
+        Time: O(n log n) average, O(n^2) worst
+        Space: O(n)
+
+    References:
+        - Hoare, C.A.R. (1961)
+
+    Args:
+        arr: Input list.
+
+    Returns:
+        Sorted list.
+    """
+
+    from __future__ import annotations
+
+
+    def quicksort(arr: list[int]) -> list[int]:
+        """Sort using quicksort.
+
+        Args:
+            arr: Input list.
+
+        Returns:
+            Sorted list.
+
+        Complexity:
+            O(n log n) average.
+        """
+        if len(arr) <= 1:
+            return arr
+        pivot = arr[0]
+        left = [x for x in arr[1:] if x <= pivot]
+        right = [x for x in arr[1:] if x > pivot]
+        return quicksort(left) + [pivot] + quicksort(right)
+
+
+    if __name__ == "__main__":
+        assert quicksort([3, 1, 2]) == [1, 2, 3]
+        assert quicksort([]) == []
+        assert quicksort([1]) == [1]
+    ''')
+
+
+class TestLintGate:
+    def test_properties(self) -> None:
+        gate = LintGate()
+        assert gate.name == "lint"
+        assert gate.max_retries == 2
+        assert gate.blocking is True
+
+    def test_pass_on_good_code(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text(_GOOD_CODE)
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(LintGate(), bundle)
+        assert result.verdict == GateVerdict.PASS
+
+    def test_fail_on_syntax_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.py"
+        f.write_text("def foo(:\n  pass")
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(LintGate(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+
+    def test_fail_on_missing_file(self) -> None:
+        bundle = _make_bundle(implementation_path="/nonexistent.py")
+        result = gate_eval(LintGate(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+
+    def test_fail_on_empty_path(self) -> None:
+        bundle = _make_bundle(implementation_path="")
+        result = gate_eval(LintGate(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+
+
+class TestCorrectnessGate:
+    def test_properties(self) -> None:
+        gate = CorrectnessGate()
+        assert gate.name == "correctness"
+        assert gate.max_retries == 1
+
+    def test_pass_on_good_code(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text(_GOOD_CODE)
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(CorrectnessGate(), bundle)
+        assert result.verdict == GateVerdict.PASS
+
+    def test_fail_on_assertion_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.py"
+        f.write_text('if __name__ == "__main__":\n    assert False\n')
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(CorrectnessGate(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+
+
+class TestConsistencyGate:
+    def test_properties(self) -> None:
+        gate = ConsistencyGate()
+        assert gate.name == "consistency"
+        assert gate.max_retries == 0
+
+    def test_pass_with_valid_impl(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text(_GOOD_CODE)
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(ConsistencyGate(), bundle, name="quicksort")
+        assert result.verdict in {GateVerdict.PASS, GateVerdict.WARN}
+
+
+class TestSchemaComplianceGate:
+    def test_properties(self) -> None:
+        gate = SchemaComplianceGate()
+        assert gate.name == "schema_compliance"
+        assert gate.max_retries == 0
+
+    def test_pass_with_good_implementation(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text(_GOOD_CODE)
+        bundle = _make_bundle(implementation_path=str(f))
+        result = gate_eval(SchemaComplianceGate(), bundle)
+        assert result.verdict in {GateVerdict.PASS, GateVerdict.WARN}
+
+
+def gate_eval(
+    gate: LintGate | CorrectnessGate | ConsistencyGate | SchemaComplianceGate,
+    bundle: ArtifactBundle,
+    name: str = "quicksort",
+) -> object:
+    item = _make_item(name)
+    return gate.evaluate(item, bundle)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,193 @@
+"""Tests for the pipeline orchestrator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from apprentice.core.pipeline import Pipeline, PipelineConfig, PipelineResult
+from apprentice.models.artifact import ArtifactBundle  # noqa: TC001
+from apprentice.models.budget import CostEstimate
+from apprentice.models.work_item import (
+    GateResult,
+    GateVerdict,
+    PipelineContext,
+    StageResult,
+    WorkItem,
+    WorkItemStatus,
+)
+
+
+class _StubStage:
+    """Minimal stage for testing pipeline orchestration."""
+
+    def __init__(self, name: str, tokens: int = 100) -> None:
+        self.name = name
+        self._tokens = tokens
+
+    def estimate_cost(self, work_item: WorkItem) -> CostEstimate:
+        return CostEstimate(
+            estimated_input_tokens=self._tokens,
+            estimated_output_tokens=0,
+            estimated_cost_usd=0.001,
+        )
+
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        return StageResult(
+            stage_name=self.name,
+            artifacts={"implementation": f"/tmp/{self.name}.py"},
+            tokens_used=self._tokens,
+            cost_usd=0.001,
+        )
+
+
+class _FailingStage(_StubStage):
+    def execute(self, work_item: WorkItem, context: PipelineContext) -> StageResult:
+        raise RuntimeError("stage failure")
+
+
+class _StubGate:
+    """Minimal gate for testing pipeline orchestration."""
+
+    def __init__(self, name: str, verdict: GateVerdict = GateVerdict.PASS) -> None:
+        self.name = name
+        self.max_retries = 0
+        self.blocking = True
+        self._verdict = verdict
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        return GateResult(gate_name=self.name, verdict=self._verdict)
+
+
+def _make_pipeline(
+    stages: dict[str, Any] | None = None,
+    gates: dict[str, Any] | None = None,
+    parallel: list[list[str]] | None = None,
+) -> Pipeline:
+    if stages is None:
+        stages = {"impl": _StubStage("impl"), "validate": _StubStage("validate")}
+    if gates is None:
+        gates = {}
+    config = PipelineConfig(
+        stages=list(stages.keys()),
+        gates={g: list(stages.keys()) for g in gates} if gates else {},
+        parallel_stages=parallel or [],
+        budget_per_stage=20_000,
+    )
+    return Pipeline(stages=stages, gates=gates, config=config)
+
+
+def _make_context(tokens: int = 100_000) -> PipelineContext:
+    return PipelineContext(
+        config={"provider": None, "artifacts": {}},
+        budget_remaining_tokens=tokens,
+        budget_remaining_usd=5.0,
+    )
+
+
+class TestPipelineBasic:
+    def test_successful_run(self) -> None:
+        pipeline = _make_pipeline()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert isinstance(result, PipelineResult)
+        assert result.success is True
+        assert item.status == WorkItemStatus.COMPLETED
+        assert result.total_tokens == 200  # two stages x 100
+
+    def test_returns_stage_results(self) -> None:
+        pipeline = _make_pipeline()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert len(result.stage_results) == 2
+
+
+class TestPipelineGates:
+    def test_passing_gate(self) -> None:
+        stages: dict[str, Any] = {"impl": _StubStage("impl")}
+        gates: dict[str, Any] = {"lint": _StubGate("lint")}
+        config = PipelineConfig(
+            stages=["impl"],
+            gates={"lint": ["impl"]},
+            parallel_stages=[],
+            budget_per_stage=20_000,
+        )
+        pipeline = Pipeline(stages=stages, gates=gates, config=config)
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert result.success is True
+        assert len(result.gate_results) == 1
+
+    def test_failing_blocking_gate_shelves(self) -> None:
+        stages: dict[str, Any] = {"impl": _StubStage("impl")}
+        gates: dict[str, Any] = {"lint": _StubGate("lint", GateVerdict.FAIL)}
+        config = PipelineConfig(
+            stages=["impl"],
+            gates={"lint": ["impl"]},
+            parallel_stages=[],
+            budget_per_stage=20_000,
+        )
+        pipeline = Pipeline(stages=stages, gates=gates, config=config)
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert result.success is False
+        assert item.status == WorkItemStatus.SHELVED
+
+    def test_warning_gate_continues(self) -> None:
+        stages: dict[str, Any] = {"impl": _StubStage("impl")}
+        gates: dict[str, Any] = {"lint": _StubGate("lint", GateVerdict.WARN)}
+        config = PipelineConfig(
+            stages=["impl"],
+            gates={"lint": ["impl"]},
+            parallel_stages=[],
+            budget_per_stage=20_000,
+        )
+        pipeline = Pipeline(stages=stages, gates=gates, config=config)
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert result.success is True
+
+
+class TestPipelineBudget:
+    def test_shelves_on_insufficient_budget(self) -> None:
+        pipeline = _make_pipeline()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        ctx = _make_context(tokens=50)  # less than stage estimate
+        result = pipeline.run(item, ctx)
+        assert result.success is False
+        assert item.status == WorkItemStatus.SHELVED
+
+
+class TestPipelineParallel:
+    def test_parallel_stages_run(self) -> None:
+        stages: dict[str, Any] = {
+            "impl": _StubStage("impl"),
+            "instr": _StubStage("instr"),
+            "viz": _StubStage("viz"),
+            "assess": _StubStage("assess"),
+        }
+        config = PipelineConfig(
+            stages=["impl", "instr", "viz", "assess"],
+            gates={},
+            parallel_stages=[["instr", "viz", "assess"]],
+            budget_per_stage=20_000,
+        )
+        pipeline = Pipeline(stages=stages, gates={}, config=config)
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        assert result.success is True
+        assert len(result.stage_results) == 4
+        assert result.total_tokens == 400
+
+
+class TestPipelineStageFailure:
+    def test_stage_exception_continues(self) -> None:
+        stages: dict[str, Any] = {
+            "impl": _FailingStage("impl"),
+            "validate": _StubStage("validate"),
+        }
+        pipeline = _make_pipeline(stages=stages)
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        result = pipeline.run(item, _make_context())
+        # Pipeline continues after stage failure
+        assert result.success is True
+        assert len(result.stage_results) == 1  # only validate succeeded

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,150 @@
+"""Tests for instrumentation, assessment, visualization, and validation stages."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from apprentice.models.work_item import PipelineContext, WorkItem
+from apprentice.stages.assessment import AssessmentStage, _extract_csv, _validate_csv
+from apprentice.stages.instrumentation import InstrumentationStage
+from apprentice.stages.validation import ValidationStage
+from apprentice.stages.visualization import VisualizationStage, _to_pascal_case
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestInstrumentationStage:
+    def test_name(self) -> None:
+        assert InstrumentationStage().name == "instrumentation"
+
+    def test_estimate_cost(self) -> None:
+        stage = InstrumentationStage()
+        item = WorkItem(id="t", algorithm_name="quicksort", tier=2)
+        est = stage.estimate_cost(item)
+        assert est.estimated_input_tokens > 0
+
+    def test_execute_requires_provider(self) -> None:
+        stage = InstrumentationStage()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        ctx = PipelineContext(config={"artifacts": {"implementation": "/nonexistent"}})
+        with pytest.raises(RuntimeError, match="[Nn]o provider"):
+            stage.execute(item, ctx)
+
+
+class TestAssessmentStage:
+    def test_name(self) -> None:
+        assert AssessmentStage().name == "assessment"
+
+    def test_estimate_cost(self) -> None:
+        stage = AssessmentStage()
+        item = WorkItem(id="t", algorithm_name="quicksort", tier=2)
+        est = stage.estimate_cost(item)
+        assert est.estimated_input_tokens > 0
+
+    def test_execute_requires_provider(self) -> None:
+        stage = AssessmentStage()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        ctx = PipelineContext(config={"artifacts": {"implementation": "/nonexistent"}})
+        with pytest.raises(RuntimeError, match="[Nn]o provider"):
+            stage.execute(item, ctx)
+
+
+class TestExtractCsv:
+    def test_extracts_csv_fence(self) -> None:
+        text = "```csv\nfront,back,tags,type\nQ1,A1,algo,concept\n```"
+        assert "front,back" in _extract_csv(text)
+
+    def test_no_fence_returns_raw(self) -> None:
+        text = "front,back,tags,type\nQ1,A1,algo,concept"
+        assert "front,back" in _extract_csv(text)
+
+
+class TestValidateCsv:
+    def test_valid_csv(self) -> None:
+        csv_text = "front,back,tags,type\n" + "\n".join(f"Q{i},A{i},algo,concept" for i in range(8))
+        issues = _validate_csv(csv_text)
+        assert len(issues) == 0
+
+    def test_too_few_rows(self) -> None:
+        csv_text = "front,back,tags,type\nQ1,A1,algo,concept"
+        issues = _validate_csv(csv_text)
+        assert any("row" in i.lower() or "card" in i.lower() for i in issues)
+
+
+class TestVisualizationStage:
+    def test_name(self) -> None:
+        assert VisualizationStage().name == "visualization"
+
+    def test_estimate_cost(self) -> None:
+        stage = VisualizationStage()
+        item = WorkItem(id="t", algorithm_name="quicksort", tier=2)
+        est = stage.estimate_cost(item)
+        assert est.estimated_input_tokens > 0
+
+    def test_execute_requires_provider(self) -> None:
+        stage = VisualizationStage()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        ctx = PipelineContext(config={"artifacts": {"implementation": "/nonexistent"}})
+        with pytest.raises(RuntimeError, match="[Nn]o provider"):
+            stage.execute(item, ctx)
+
+
+class TestToPascalCase:
+    def test_snake_case(self) -> None:
+        assert _to_pascal_case("quick_sort") == "QuickSort"
+
+    def test_single_word(self) -> None:
+        assert _to_pascal_case("dijkstra") == "Dijkstra"
+
+    def test_hyphenated(self) -> None:
+        assert _to_pascal_case("merge-sort") == "MergeSort"
+
+
+class TestValidationStage:
+    def test_name(self) -> None:
+        assert ValidationStage().name == "validation"
+
+    def test_estimate_cost_zero_llm(self) -> None:
+        stage = ValidationStage()
+        item = WorkItem(id="t", algorithm_name="test", tier=1)
+        est = stage.estimate_cost(item)
+        assert est.estimated_cost_usd == 0.0
+
+    def test_validates_good_implementation(self, tmp_path: Path) -> None:
+        impl = tmp_path / "quicksort.py"
+        impl.write_text(
+            textwrap.dedent('''\
+            """Quicksort implementation."""
+
+
+            def quicksort(arr: list[int]) -> list[int]:
+                """Sort a list using quicksort.
+
+                Complexity:
+                    Time: O(n log n) average
+                    Space: O(n)
+                """
+                if len(arr) <= 1:
+                    return arr
+                pivot = arr[0]
+                left = [x for x in arr[1:] if x <= pivot]
+                right = [x for x in arr[1:] if x > pivot]
+                return quicksort(left) + [pivot] + quicksort(right)
+
+            if __name__ == "__main__":
+                assert quicksort([3, 1, 2]) == [1, 2, 3]
+            ''')
+        )
+
+        stage = ValidationStage()
+        item = WorkItem(id="t", algorithm_name="quicksort", tier=2)
+        ctx = PipelineContext(config={"artifacts": {"implementation": str(impl)}})
+        result = stage.execute(item, ctx)
+        assert result.tokens_used == 0
+        # At least correctness and complexity checks should pass
+        passed = [d for d in result.diagnostics if d.get("passed")]
+        assert len(passed) >= 2


### PR DESCRIPTION
## Summary

Complete assisted-mode pipeline (v0.2) — all 7 pipeline stages, 4 quality gates, config-driven orchestrator with parallel execution, and expanded CLI.

### New Stages

- **Discovery** — LLM-driven candidate algorithm suggestions with Levenshtein fuzzy deduplication (>=0.85 threshold), name normalization, `[a-z0-9_]` whitelist, catalog-aware filtering
- **Instrumentation** — adds JSON trace hooks (`step`, `operation`, `state`) at algorithmic decision points for learner replay
- **Visualization** — generates Manim animation steps injected into a Jinja2 scaffold template (reduces hallucination vs open-ended generation). PascalCase class naming, color palette constants
- **Assessment** — produces Anki CSV flashcards with 4 card types (concept, complexity, implementation, comparison), minimum 8 cards, with CSV structure validation
- **Validation** — local-only checks (no LLM): subprocess correctness execution, AST complexity doc inspection, Manim Scene structure, Anki CSV format, trace key detection. Writes JSON report

### Quality Gates

- **LintGate** — syntax, module/function docstrings, type annotations, no wildcards, file size cap. Max 2 auto-fix retries
- **CorrectnessGate** — subprocess execution with 5s timeout. 1 retry with re-prompt
- **ConsistencyGate** — structural checks (file existence, valid AST, CSV columns) block; semantic checks (name/complexity cross-match) warn
- **SchemaComplianceGate** — validates against `no-magic-schema.yaml`: docstring sections, trace keys, card types, Scene subclass

### Pipeline Orchestrator

- Config-driven stage ordering via `PipelineConfig` dataclass
- Gate insertion points mapped to stage names
- `ThreadPoolExecutor(max_workers=3)` for parallel stages (instrumentation, visualization, assessment)
- Budget pre-check (token cap + remaining budget) and post-check (drift logging)
- Work item shelved on blocking gate failure or budget exhaustion
- Full observability: `log_stage_metrics()` and `log_gate_result()` after every stage/gate

### CLI Expansion

- `apprentice build` now runs the full pipeline (not just implementation stage)
- `apprentice suggest --tier N --limit N` — runs discovery stage
- `apprentice preview` — lists last build artifacts with content previews

### Prompt Templates

- 4 new versioned YAML templates: `discovery.yaml`, `instrumentation.yaml`, `visualization.yaml`, `assessment.yaml`
- All follow the same structure as `implementation.yaml` with Jinja2 `StrictUndefined`

### Architecture

```
Pipeline flow:
  Implementation → Lint Gate → Correctness Gate
       ↓ (if pass)
  Instrumentation ∥ Visualization ∥ Assessment  (parallel)
       ↓
  Validation → Consistency Gate → Schema Compliance Gate
```

### Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run mypy --strict` — 37 source files, 0 issues
- `uv run pytest` — **125 tests passed** (53 new + 72 existing)

## Test plan

- [x] Discovery: Levenshtein distance, name normalization, duplicate detection, stage properties
- [x] Instrumentation: name, cost estimate, provider requirement
- [x] Assessment: name, cost estimate, CSV extraction, CSV validation (valid/too-few-rows)
- [x] Visualization: name, cost estimate, provider requirement, PascalCase conversion
- [x] Validation: zero-cost LLM, correctness + complexity checks pass on good implementation
- [x] LintGate: pass on good code, fail on syntax error, fail on missing/empty path
- [x] CorrectnessGate: pass on good code, fail on assertion error
- [x] ConsistencyGate: pass/warn on valid implementation
- [x] SchemaComplianceGate: pass on compliant implementation
- [x] Pipeline: successful run, stage results, passing/failing/warning gates, budget shelving, parallel execution, stage exception recovery