### PR TITLE
fix(agents): resolve session state errors and cap LLM calls

### DIFF
--- a/src/apprentice/agents/assessment.py
+++ b/src/apprentice/agents/assessment.py
@@ -14,7 +14,8 @@ You are an expert spaced-repetition card author for the no-magic educational pro
 Your task is to generate Anki flashcards in CSV format covering an algorithm's
 concepts, complexity, and implementation details.
 
-The implementation code is available at: {implementation_path}
+The implementation code is provided in the conversation history as
+the generated_code output from the drafter agent.
 
 Card authoring rules:
 - Each card tests exactly one concept — never combine two questions.
@@ -42,7 +43,7 @@ Do NOT use markdown fences. Write ONLY the CSV content, nothing else.
 def build_assessment_agent(model: LiteLlm) -> LlmAgent:
     """Build an ADK LlmAgent for Anki flashcard generation.
 
-    Reads {implementation_path} from session state and produces
+    Reads the generated code from conversation history and produces
     a CSV-format Anki deck.
 
     Args:

--- a/src/apprentice/agents/implementation.py
+++ b/src/apprentice/agents/implementation.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from google.adk.agents import LlmAgent, LoopAgent
 from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
+from apprentice.validators.tools import correctness_validate, lint_validate, stdlib_check
+
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
-
-from apprentice.validators.tools import correctness_validate, lint_validate, stdlib_check
 
 _DRAFTER_INSTRUCTION = """\
 You are an expert algorithm implementer for the no-magic educational project.
@@ -22,29 +24,44 @@ You write clean, well-documented Python implementations with:
 - Reference test cases in an `if __name__ == "__main__":` block
 
 Generate the algorithm implementation based on the task description.
-If previous feedback is available in {{review_feedback}}, fix ALL listed issues.
+If the conversation history contains feedback from a previous review,
+fix ALL listed issues in your new implementation.
 
 Write the complete Python source code. Do NOT use markdown fences.
 Write ONLY the Python source code, nothing else.
-
-Save the generated code by writing it to the session state under the key 'generated_code'.
 """
 
 _REVIEWER_INSTRUCTION = """\
 You are a code reviewer for algorithm implementations.
 Your job is to validate generated code using the available tools.
 
-The generated code is available at the file path in {{implementation_path}}.
-
 Steps:
-1. Run stdlib_check on the implementation file to verify no third-party imports.
-2. Run lint_validate on the implementation file to check style and structure.
-3. Run correctness_validate on the implementation file to verify it executes cleanly.
+1. First, call save_code with the generated code from the previous message to write it to disk.
+2. Use the returned file path to run stdlib_check to verify no third-party imports.
+3. Run lint_validate on the same file path to check style and structure.
+4. Run correctness_validate on the same file path to verify it executes cleanly.
 
 If ALL validators pass, call the exit_loop tool to finish successfully.
 If any validator fails, summarize the issues clearly for the drafter to fix.
 Include the specific error messages and suggestions in your feedback.
 """
+
+
+def save_code(code: str, algorithm_name: str = "algorithm") -> dict[str, Any]:
+    """Save generated Python code to a temporary file for validation.
+
+    Args:
+        code: The Python source code to save.
+        algorithm_name: Name used for the temp file (default: "algorithm").
+
+    Returns:
+        Dict with 'path' to the saved file.
+    """
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    dest = tmp_dir / f"{algorithm_name}.py"
+    dest.write_text(code, encoding="utf-8")
+    return {"path": str(dest)}
 
 
 def build_implementation_agent(
@@ -75,7 +92,7 @@ def build_implementation_agent(
         name="self_reviewer",
         model=model,
         instruction=_REVIEWER_INSTRUCTION,
-        tools=[lint_validate, correctness_validate, stdlib_check, exit_loop],
+        tools=[save_code, lint_validate, correctness_validate, stdlib_check, exit_loop],
         output_key="review_feedback",
     )
 

--- a/src/apprentice/agents/instrumentation.py
+++ b/src/apprentice/agents/instrumentation.py
@@ -14,9 +14,10 @@ You are an expert in algorithm instrumentation for the no-magic educational proj
 Your task is to add trace hooks to a clean algorithm implementation so that learners
 can observe each meaningful step as it executes.
 
-The implementation code is available at: {implementation_path}
+The original implementation code is provided in the conversation history as
+the generated_code output from the drafter agent.
 
-Read the implementation and add trace hooks following these rules:
+Instrumentation rules:
 - Never alter the algorithm's correctness or time complexity class.
 - Emit trace events as JSON dicts with keys: "step", "operation", "state".
 - Place hooks at semantically meaningful points: comparisons, swaps,
@@ -34,7 +35,7 @@ Write ONLY the Python source code, nothing else.
 def build_instrumentation_agent(model: LiteLlm) -> LlmAgent:
     """Build an ADK LlmAgent for algorithm instrumentation.
 
-    Reads {implementation_path} from session state and produces
+    Reads the generated code from conversation history and produces
     instrumented code with trace hooks.
 
     Args:

--- a/src/apprentice/agents/review.py
+++ b/src/apprentice/agents/review.py
@@ -2,36 +2,91 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from google.adk.agents import LlmAgent, LoopAgent
 from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
+from apprentice.validators.tools import consistency_validate, schema_validate
+
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
-
-from apprentice.validators.tools import consistency_validate, schema_validate
 
 _REVIEWER_INSTRUCTION = """\
 You are a quality reviewer for algorithm artifacts in the no-magic educational project.
 Your job is to validate all generated artifacts for consistency and schema compliance.
 
-The artifacts are available at paths stored in the session state:
-- Implementation: {implementation_path}
-- Instrumented: {instrumented_path}
-- Manim scene: {manim_scene_path}
-- Anki deck: {anki_deck_path}
+The artifacts are available in the conversation history:
+- generated_code: the implementation source code
+- instrumented_code: the instrumented source code
+- manim_scene_code: the Manim visualization scene
+- anki_deck_content: the Anki flashcard CSV
 
 Steps:
-1. Build a JSON string mapping artifact types to their file paths from the session state.
-   Format: '{{"implementation": "...", "instrumented": "...", "manim_scene": "...", "anki_deck": "..."}}'
-2. Call consistency_validate with the artifacts JSON to check cross-artifact consistency.
-3. Call schema_validate with the artifacts JSON to check schema compliance.
+1. Call save_artifacts to write all artifact content to temporary files.
+   Pass the generated code, instrumented code, manim scene, and anki deck content
+   from the conversation history.
+2. Use the returned file paths to call consistency_validate with the artifacts JSON.
+3. Call schema_validate with the same artifacts JSON.
 
 If ALL validators pass (both return passed=true), call exit_loop to finish successfully.
 If any validator reports structural failures (severity="error"), compile detailed feedback
 describing what needs to be fixed.
 """
+
+
+def save_artifacts(
+    implementation_code: str = "",
+    instrumented_code: str = "",
+    manim_scene_code: str = "",
+    anki_deck_content: str = "",
+    algorithm_name: str = "algorithm",
+) -> dict[str, Any]:
+    """Save all artifact content to temporary files for validation.
+
+    Args:
+        implementation_code: Python source code for the algorithm.
+        instrumented_code: Python source with trace hooks.
+        manim_scene_code: Manim Scene Python source.
+        anki_deck_content: CSV content for Anki flashcards.
+        algorithm_name: Name used for temp file stems.
+
+    Returns:
+        Dict with file paths and a pre-built artifacts_json string
+        ready to pass to consistency_validate and schema_validate.
+    """
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    paths: dict[str, str] = {}
+
+    if implementation_code:
+        impl_path = tmp_dir / f"{algorithm_name}.py"
+        impl_path.write_text(implementation_code, encoding="utf-8")
+        paths["implementation"] = str(impl_path)
+
+    if instrumented_code:
+        instr_path = tmp_dir / f"{algorithm_name}_instrumented.py"
+        instr_path.write_text(instrumented_code, encoding="utf-8")
+        paths["instrumented"] = str(instr_path)
+
+    if manim_scene_code:
+        manim_path = tmp_dir / f"{algorithm_name}_scene.py"
+        manim_path.write_text(manim_scene_code, encoding="utf-8")
+        paths["manim_scene"] = str(manim_path)
+
+    if anki_deck_content:
+        anki_path = tmp_dir / f"{algorithm_name}_cards.csv"
+        anki_path.write_text(anki_deck_content, encoding="utf-8")
+        paths["anki_deck"] = str(anki_path)
+
+    return {
+        "paths": paths,
+        "artifacts_json": json.dumps(paths),
+    }
 
 
 def build_review_agent(
@@ -54,7 +109,7 @@ def build_review_agent(
         name="reviewer",
         model=model,
         instruction=_REVIEWER_INSTRUCTION,
-        tools=[consistency_validate, schema_validate, exit_loop],
+        tools=[save_artifacts, consistency_validate, schema_validate, exit_loop],
         output_key="review_verdict",
         description="Validates artifacts for consistency and schema compliance.",
     )

--- a/src/apprentice/agents/visualization.py
+++ b/src/apprentice/agents/visualization.py
@@ -19,7 +19,8 @@ You are an expert Manim animator for the no-magic educational project.
 Your task is to generate a complete Manim animation scene that visualizes
 an algorithm's execution.
 
-The implementation code is available at: {implementation_path}
+The implementation code is provided in the conversation history as
+the generated_code output from the drafter agent.
 
 Animation rules:
 - Each animation step must correspond to a semantically meaningful algorithmic event
@@ -54,7 +55,7 @@ def load_manim_template() -> dict[str, Any]:
 def build_visualization_agent(model: LiteLlm) -> LlmAgent:
     """Build an ADK LlmAgent for Manim visualization generation.
 
-    Reads {implementation_path} from session state and produces
+    Reads the generated code from conversation history and produces
     a Manim Scene script.
 
     Args:

--- a/src/apprentice/cli.py
+++ b/src/apprentice/cli.py
@@ -282,7 +282,7 @@ async def _run_pipeline(
         session=session,
         session_service=session_service,
         artifact_service=artifact_service,
-        run_config=RunConfig(),
+        run_config=RunConfig(max_llm_calls=50),
     )
 
     async for _event in pipeline.run_async(ctx):
@@ -325,7 +325,7 @@ async def _run_agent(agent: Any, prompt: str) -> dict[str, Any]:
         session=session,
         session_service=session_service,
         artifact_service=artifact_service,
-        run_config=RunConfig(),
+        run_config=RunConfig(max_llm_calls=30),
     )
 
     async for _event in agent.run_async(ctx):


### PR DESCRIPTION
## Summary

- **Session state resolution**: ADK eagerly resolves `{var}` in agent instructions from session state before each LLM call. Three categories of errors fixed where referenced variables didn't exist.
- **Bridge tools**: Added `save_code` and `save_artifacts` tools so agents can write generated text content to temp files for file-based validators.
- **LLM call cap**: Set `max_llm_calls=50` on pipeline RunConfig (30 for single agents) to prevent runaway loops when local models fail to call `exit_loop`.

## Root Causes

1. **`{review_feedback}` in drafter**: Doesn't exist on first LoopAgent iteration. Fix: removed reference — conversation history carries feedback naturally between iterations.

2. **`{implementation_path}` everywhere**: Never set by any agent. Drafter writes code as text to `generated_code` session state, not a file path. Fix: added `save_code` tool to self_reviewer that writes code to disk, then validators use the returned path.

3. **Artifact paths in review agent**: `{instrumented_path}`, `{manim_scene_path}`, `{anki_deck_path}` not set as session state. Fix: added `save_artifacts` tool that writes all artifact content to temp files and returns paths for validators.

4. **Runaway LLM calls**: 8B local models (gemma4) don't reliably call `exit_loop` after validators pass, causing 82+ LLM calls in a single run. Fix: `RunConfig(max_llm_calls=50)`.

## Validated

- Pipeline successfully executes against Ollama (gemma4:latest) — LLM calls, tool execution, and agent-to-agent data flow all working
- 249 tests passing, ruff clean, mypy --strict clean

## Test plan
- [x] `uv run pytest tests/` — 249 passed
- [x] `uv run ruff check src/ tests/` — 0 errors
- [x] `uv run mypy --strict src/apprentice/` — 0 errors
- [x] Integration test against Ollama gemma4 — pipeline executes, makes tool calls, generates code