### PR TITLE
feat(ui): add Rich progress display and suppress LLM logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "litellm>=1.50.0",
     "openai>=2.30.0",
     "pyyaml>=6.0.3",
+    "rich>=14.3.3",
     "tomli>=2.0; python_version < '3.11'",
 ]
 

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -22,12 +22,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-# Ensure src/ is importable
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from apprentice.core.config import load_config
 from apprentice.core.metrics import PipelineReport, aggregate_runs
 from apprentice.core.observability import get_logger, setup_logging
+from apprentice.core.progress import IntegrationProgress, suppress_noisy_loggers
 from apprentice.core.session_store import RunRecord, SessionStore
 
 _REPORT_DIR = Path.home() / ".apprentice" / "reports"
@@ -132,7 +132,11 @@ def _run_single(
             logger.info("completed: %s in %.1fs", algorithm, elapsed)
         else:
             record = store.fail_run(
-                record, session_state, budget_summary, elapsed, "no generated_code in session state"
+                record,
+                session_state,
+                budget_summary,
+                elapsed,
+                "no generated_code in session state",
             )
             logger.warning("failed: %s in %.1fs — no output", algorithm, elapsed)
 
@@ -144,11 +148,6 @@ def _run_single(
     return record
 
 
-def _generate_report(records: list[RunRecord]) -> PipelineReport:
-    """Generate a report from run records."""
-    return aggregate_runs(records)
-
-
 def _save_report(report: PipelineReport) -> Path:
     """Save the report as a JSON file."""
     _REPORT_DIR.mkdir(parents=True, exist_ok=True)
@@ -158,11 +157,6 @@ def _save_report(report: PipelineReport) -> Path:
     return path
 
 
-def _print_report(report: PipelineReport) -> None:
-    """Print a summary of the report."""
-    print(json.dumps(report.to_dict(), indent=2, default=str))
-
-
 def main() -> int:
     args = _parse_args()
 
@@ -170,6 +164,7 @@ def main() -> int:
     setup_logging(
         {"log_level": cfg.observability.log_level, "log_path": cfg.observability.log_path}
     )
+    suppress_noisy_loggers()
     logger = get_logger("integration_test")
 
     store = SessionStore()
@@ -179,39 +174,55 @@ def main() -> int:
         if not records:
             print("No past runs found.")
             return 0
-        report = _generate_report(records)
-        _print_report(report)
+        report = aggregate_runs(records)
+        progress = IntegrationProgress(0, "", "")
+        progress.print_summary(report)
         return 0
 
     algorithms = _select_algorithms(args.tier, args.limit)
+    backend = args.backend or cfg.provider.backend
+    model_str = args.model or cfg.provider.model
 
     if args.dry_run:
-        print(f"Would test {len(algorithms)} algorithms:")
+        from rich.console import Console
+
+        console = Console(stderr=True)
+        console.print(f"[bold]Would test {len(algorithms)} algorithms:[/]")
         for name, tier in algorithms:
-            print(f"  - {name} (tier {tier})")
-        print(f"Backend: {args.backend or cfg.provider.backend}")
-        print(f"Model: {args.model or cfg.provider.model}")
+            console.print(f"  [dim]•[/] {name} [dim](tier {tier})[/]")
+        console.print(f"[dim]Backend:[/] {backend}")
+        console.print(f"[dim]Model:[/] {model_str}")
         return 0
 
     logger.info("starting integration test: %d algorithms", len(algorithms))
+
+    ip = IntegrationProgress(len(algorithms), backend, model_str)
     records: list[RunRecord] = []
 
-    for algorithm, tier in algorithms:
-        record = _run_single(algorithm, tier, cfg, args.backend, args.model, store, logger)
-        records.append(record)
+    with ip.start():
+        for algorithm, tier in algorithms:
+            ip.on_algorithm_start(algorithm, tier)
+            record = _run_single(algorithm, tier, cfg, args.backend, args.model, store, logger)
+            records.append(record)
+            ip.on_algorithm_complete(
+                algorithm,
+                record.status == "completed",
+                record.elapsed_seconds,
+            )
 
-    report = _generate_report(records)
+    report = aggregate_runs(records)
     report_path = _save_report(report)
 
-    _print_report(report)
+    ip.print_summary(report)
     logger.info("report saved to %s", report_path)
 
     target_rate = 0.95
     if report.success_rate < target_rate:
-        logger.warning(
-            "success rate %.1f%% below target %.1f%%",
-            report.success_rate * 100,
-            target_rate * 100,
+        from rich.console import Console
+
+        Console(stderr=True).print(
+            f"[bold red]Success rate {report.success_rate * 100:.0f}% "
+            f"below target {target_rate * 100:.0f}%[/]"
         )
         return 1
 

--- a/src/apprentice/cli.py
+++ b/src/apprentice/cli.py
@@ -150,12 +150,11 @@ def _resolve_model(cfg: ApprenticeConfig, args: Any) -> Any:
 
 
 def _cmd_build(cfg: ApprenticeConfig, args: Any) -> int:
-    from apprentice.core.observability import get_logger
     from apprentice.core.orchestrator import build_pipeline, get_budget_tracker_from_pipeline
+    from apprentice.core.progress import PipelineProgress, suppress_noisy_loggers
     from apprentice.core.session_store import SessionStore
 
-    logger = get_logger(__name__)
-    logger.info("build started: %s (tier %d)", args.algorithm, args.tier)
+    suppress_noisy_loggers()
 
     store = SessionStore()
     record = store.create_run(args.algorithm, args.tier)
@@ -163,10 +162,13 @@ def _cmd_build(cfg: ApprenticeConfig, args: Any) -> int:
     model = _resolve_model(cfg, args)
     pipeline = build_pipeline(model, cfg, include_packaging=False)
 
+    progress = PipelineProgress(args.algorithm, args.tier)
     start = time.monotonic()
     try:
         session_state = asyncio.run(
-            _run_pipeline(pipeline, args.algorithm, args.tier, args.description)
+            _run_pipeline_with_progress(
+                pipeline, args.algorithm, args.tier, args.description, progress
+            )
         )
         elapsed = time.monotonic() - start
 
@@ -176,17 +178,19 @@ def _cmd_build(cfg: ApprenticeConfig, args: Any) -> int:
         has_output = bool(session_state.get("generated_code"))
         if has_output:
             store.complete_run(record, session_state, budget_summary, elapsed)
+            progress.finish(True, elapsed)
         else:
             store.fail_run(record, session_state, budget_summary, elapsed, "no output generated")
+            progress.finish(False, elapsed)
 
     except Exception as exc:
         elapsed = time.monotonic() - start
         store.fail_run(record, {}, {}, elapsed, str(exc))
-        logger.error("build failed: %s", exc)
+        progress.finish(False, elapsed)
         _print_json({"error": str(exc), "run_id": record.run_id})
         return 1
 
-    _print_build_result(args.algorithm, args.tier, session_state, elapsed, record.run_id)
+    progress.print_result(session_state, record.run_id)
     return 0
 
 
@@ -238,6 +242,17 @@ async def _run_pipeline(
     description: str,
 ) -> dict[str, Any]:
     """Run the ADK pipeline and return the final session state."""
+    return await _run_pipeline_with_progress(pipeline, algorithm, tier, description, None)
+
+
+async def _run_pipeline_with_progress(
+    pipeline: Any,
+    algorithm: str,
+    tier: int,
+    description: str,
+    progress: Any,
+) -> dict[str, Any]:
+    """Run the ADK pipeline with optional progress tracking."""
     from google.adk.agents import InvocationContext, RunConfig
     from google.adk.artifacts import InMemoryArtifactService
     from google.adk.events.event import Event
@@ -285,8 +300,13 @@ async def _run_pipeline(
         run_config=RunConfig(max_llm_calls=50),
     )
 
-    async for _event in pipeline.run_async(ctx):
-        pass
+    if progress is not None:
+        with progress.start():
+            async for event in pipeline.run_async(ctx):
+                progress.on_event(event)
+    else:
+        async for _event in pipeline.run_async(ctx):
+            pass
 
     return dict(session.state)
 

--- a/src/apprentice/core/progress.py
+++ b/src/apprentice/core/progress.py
@@ -1,0 +1,245 @@
+"""Rich progress display for pipeline execution."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from rich.console import Console
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.table import Table
+
+console = Console(stderr=True)
+
+_AGENT_LABELS: dict[str, str] = {
+    "apprentice_pipeline": "Pipeline",
+    "implementation_loop": "Implementation",
+    "drafter": "Drafting code",
+    "self_reviewer": "Validating code",
+    "artifact_generation": "Generating artifacts",
+    "instrumentation": "Instrumenting",
+    "visualization": "Creating Manim scene",
+    "assessment": "Generating Anki cards",
+    "review_loop": "Reviewing artifacts",
+    "reviewer": "Running validators",
+    "packaging": "Creating PRs",
+    "discovery": "Discovering algorithms",
+}
+
+_PIPELINE_STAGES = [
+    "implementation_loop",
+    "artifact_generation",
+    "review_loop",
+]
+
+
+def suppress_noisy_loggers() -> None:
+    """Suppress LiteLLM, httpx, and other verbose loggers."""
+    for name in ("LiteLLM", "litellm", "httpx", "httpcore", "openai", "anthropic"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+class PipelineProgress:
+    """Tracks and displays pipeline execution progress using Rich.
+
+    Provides a spinner showing the current agent, a progress bar for
+    pipeline stages, and an LLM call counter.
+    """
+
+    def __init__(self, algorithm: str, tier: int) -> None:
+        self._algorithm = algorithm
+        self._tier = tier
+        self._llm_calls = 0
+        self._current_agent = ""
+        self._start_time = time.monotonic()
+        self._stage_index = 0
+        self._events: list[str] = []
+        self._progress = Progress(
+            SpinnerColumn("dots"),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(bar_width=30),
+            TextColumn("[dim]{task.fields[detail]}"),
+            TimeElapsedColumn(),
+            console=console,
+            transient=False,
+        )
+        self._task_id = self._progress.add_task(
+            f"Building {algorithm} (tier {tier})",
+            total=len(_PIPELINE_STAGES),
+            detail="starting...",
+        )
+
+    def start(self) -> Progress:
+        """Return the Progress instance for use as a context manager."""
+        return self._progress
+
+    def on_event(self, event: Any) -> None:
+        """Process an ADK event to update the display."""
+        author = getattr(event, "author", "")
+        if not author or author == "user":
+            return
+
+        label = _AGENT_LABELS.get(author, author)
+
+        if author != self._current_agent:
+            self._current_agent = author
+            if author in _PIPELINE_STAGES:
+                self._stage_index = _PIPELINE_STAGES.index(author)
+                self._progress.update(
+                    self._task_id,
+                    completed=self._stage_index,
+                    detail=label,
+                )
+            else:
+                self._progress.update(self._task_id, detail=label)
+
+        content = getattr(event, "content", None)
+        if content and getattr(content, "parts", None):
+            for part in content.parts:
+                if getattr(part, "function_call", None):
+                    tool_name = part.function_call.name
+                    self._progress.update(
+                        self._task_id,
+                        detail=f"{label} → {tool_name}()",
+                    )
+                elif getattr(part, "function_response", None) or getattr(part, "text", None):
+                    self._llm_calls += 1
+                    self._progress.update(
+                        self._task_id,
+                        detail=f"{label} [{self._llm_calls} LLM calls]",
+                    )
+
+    def finish(self, success: bool, elapsed: float) -> None:
+        """Mark pipeline as complete and update the display."""
+        status = "[bold green]completed" if success else "[bold red]failed"
+        self._progress.update(
+            self._task_id,
+            completed=len(_PIPELINE_STAGES),
+            detail=f"{status} in {elapsed:.1f}s ({self._llm_calls} LLM calls)",
+        )
+
+    def print_result(self, session_state: dict[str, Any], run_id: str = "") -> None:
+        """Print a formatted result summary."""
+        table = Table(
+            title=f"Build Result: {self._algorithm}", show_header=False, border_style="dim"
+        )
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+
+        if run_id:
+            table.add_row("Run ID", run_id)
+        table.add_row("Algorithm", self._algorithm)
+        table.add_row("Tier", str(self._tier))
+
+        artifacts = {
+            "Implementation": bool(session_state.get("generated_code")),
+            "Instrumentation": bool(session_state.get("instrumented_code")),
+            "Visualization": bool(session_state.get("manim_scene_code")),
+            "Assessment": bool(session_state.get("anki_deck_content")),
+        }
+        for name, present in artifacts.items():
+            icon = "[green]yes[/]" if present else "[red]no[/]"
+            table.add_row(name, icon)
+
+        elapsed = time.monotonic() - self._start_time
+        table.add_row("Duration", f"{elapsed:.1f}s")
+        table.add_row("LLM Calls", str(self._llm_calls))
+
+        console.print(table)
+
+
+class IntegrationProgress:
+    """Tracks progress across multiple algorithm runs."""
+
+    def __init__(self, total: int, backend: str, model: str) -> None:
+        self._total = total
+        self._completed = 0
+        self._succeeded = 0
+        self._failed = 0
+        self._progress = Progress(
+            SpinnerColumn("dots"),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(bar_width=30),
+            TextColumn("{task.fields[detail]}"),
+            TextColumn("[dim]{task.completed}/{task.total}"),
+            TimeElapsedColumn(),
+            console=console,
+        )
+        self._task_id = self._progress.add_task(
+            f"Integration test ({backend}/{model})",
+            total=total,
+            detail="starting...",
+        )
+
+    def start(self) -> Progress:
+        return self._progress
+
+    def on_algorithm_start(self, algorithm: str, tier: int) -> None:
+        self._progress.update(
+            self._task_id,
+            detail=f"[yellow]{algorithm}[/] (tier {tier})",
+        )
+
+    def on_algorithm_complete(self, algorithm: str, success: bool, elapsed: float) -> None:
+        self._completed += 1
+        if success:
+            self._succeeded += 1
+            status = "[green]pass[/]"
+        else:
+            self._failed += 1
+            status = "[red]fail[/]"
+        self._progress.update(
+            self._task_id,
+            completed=self._completed,
+            detail=f"{algorithm} {status} ({elapsed:.0f}s)",
+        )
+
+    def print_summary(self, report: Any) -> None:
+        """Print a formatted summary table."""
+        table = Table(title="Integration Test Results", border_style="dim")
+        table.add_column("Metric", style="bold")
+        table.add_column("Value", justify="right")
+
+        rate = report.success_rate * 100
+        rate_style = "green" if rate >= 95 else "yellow" if rate >= 80 else "red"
+        table.add_row("Success Rate", f"[{rate_style}]{rate:.0f}%[/]")
+        table.add_row("Total Runs", str(report.total_runs))
+        table.add_row("Passed", f"[green]{report.successful_runs}[/]")
+        table.add_row("Failed", f"[red]{report.failed_runs}[/]")
+        table.add_row("Total Cost", f"${report.total_cost_usd:.4f}")
+        table.add_row("Avg Cost/Algo", f"${report.avg_cost_per_algorithm:.4f}")
+        table.add_row("Total Duration", f"{report.total_duration_seconds:.1f}s")
+
+        console.print(table)
+
+        if report.per_agent:
+            agent_table = Table(title="Per-Agent Breakdown", border_style="dim")
+            agent_table.add_column("Agent", style="bold")
+            agent_table.add_column("Calls", justify="right")
+            agent_table.add_column("Tokens", justify="right")
+            agent_table.add_column("Cost", justify="right")
+            for name, metrics in sorted(report.per_agent.items()):
+                agent_table.add_row(
+                    name,
+                    str(metrics.total_calls),
+                    f"{metrics.total_tokens:,}",
+                    f"${metrics.total_cost_usd:.4f}",
+                )
+            console.print(agent_table)
+
+        if report.algorithms:
+            algo_table = Table(title="Algorithm Results", border_style="dim")
+            algo_table.add_column("Algorithm", style="bold")
+            algo_table.add_column("Tier", justify="center")
+            algo_table.add_column("Status")
+            algo_table.add_column("Duration", justify="right")
+            for algo in report.algorithms:
+                status_str = "[green]pass[/]" if algo["status"] == "completed" else "[red]fail[/]"
+                algo_table.add_row(
+                    algo["algorithm"],
+                    str(algo["tier"]),
+                    status_str,
+                    f"{algo['elapsed_seconds']:.1f}s",
+                )
+            console.print(algo_table)

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,7 @@ dependencies = [
     { name = "litellm", version = "1.83.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "openai" },
     { name = "pyyaml" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -216,6 +217,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.50.0" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "rich", specifier = ">=14.3.3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 


### PR DESCRIPTION
## Summary

Replaces raw LiteLLM INFO log spam with a clean Rich progress display.

### Before
```
10:48:57 - LiteLLM:INFO: utils.py:4004 -
LiteLLM completion() model= gpt-5-mini; provider = openai
10:49:21 - LiteLLM:INFO: utils.py:4004 -
LiteLLM completion() model= gpt-5-mini; provider = openai
... (repeating endlessly)
```

### After
```
⠋ Building insertion_sort (tier 1) ━━━━━━━━━━━━━━━━━━━━ Validating code → lint_validate() [8 LLM calls] 0:02:15
```

## Changes

- **`core/progress.py`**: `PipelineProgress` (single build spinner + result table) and `IntegrationProgress` (multi-algorithm progress bar + summary tables)
- **`cli.py`**: `build` command uses `PipelineProgress` to track ADK events in real-time; `_run_pipeline_with_progress` intercepts yielded events
- **`scripts/integration_test.py`**: Uses `IntegrationProgress` with per-algorithm status and formatted summary tables (success rate, per-agent costs, algorithm results)
- **Log suppression**: LiteLLM, httpx, openai, anthropic loggers set to WARNING — logs still reach the JSON file handler, just not the console
- **`rich>=14.3.3`** added to dependencies

## Test plan
- [x] 249 tests passing, ruff clean, mypy --strict clean
- [ ] `apprentice build "insertion_sort" --tier 1` shows spinner instead of log spam
- [ ] `uv run python scripts/integration_test.py --dry-run` shows formatted output