### PR TITLE
fix(agents): collapse multi-tool validation into single composite calls

### DIFF
--- a/src/apprentice/agents/implementation.py
+++ b/src/apprentice/agents/implementation.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING, Any
 from google.adk.agents import LlmAgent, LoopAgent
 from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
-from apprentice.validators.tools import correctness_validate, lint_validate, stdlib_check
-
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
 
@@ -33,35 +31,50 @@ Write ONLY the Python source code, nothing else.
 
 _REVIEWER_INSTRUCTION = """\
 You are a code reviewer for algorithm implementations.
-Your job is to validate generated code using the available tools.
 
-Steps:
-1. First, call save_code with the generated code from the previous message to write it to disk.
-2. Use the returned file path to run stdlib_check to verify no third-party imports.
-3. Run lint_validate on the same file path to check style and structure.
-4. Run correctness_validate on the same file path to verify it executes cleanly.
+Call validate_implementation with the COMPLETE Python source code from the \
+drafter's previous message. The tool saves the code to disk and runs all \
+validators (stdlib-only imports, lint, correctness) in one step.
 
-If ALL validators pass, call the exit_loop tool to finish successfully.
-If any validator fails, summarize the issues clearly for the drafter to fix.
-Include the specific error messages and suggestions in your feedback.
+If the tool returns all_passed=true, call exit_loop immediately.
+If any validator failed, respond with a summary of the failures for the drafter.
 """
 
 
-def save_code(code: str, algorithm_name: str = "algorithm") -> dict[str, Any]:
-    """Save generated Python code to a temporary file for validation.
+def validate_implementation(code: str, algorithm_name: str = "algorithm") -> dict[str, Any]:
+    """Save code to disk and run all validators in a single call.
+
+    Writes the code to a temp file, then runs stdlib check, lint validation,
+    and correctness validation. Returns combined results.
 
     Args:
-        code: The Python source code to save.
-        algorithm_name: Name used for the temp file (default: "algorithm").
+        code: Complete Python source code to validate.
+        algorithm_name: Name for the temp file (default: "algorithm").
 
     Returns:
-        Dict with 'path' to the saved file.
+        Dict with 'all_passed' bool, 'file_path', and per-validator results.
     """
+    from apprentice.validators.tools import correctness_validate, lint_validate, stdlib_check
+
     tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
     tmp_dir.mkdir(parents=True, exist_ok=True)
     dest = tmp_dir / f"{algorithm_name}.py"
     dest.write_text(code, encoding="utf-8")
-    return {"path": str(dest)}
+    file_path = str(dest)
+
+    stdlib_result = stdlib_check(file_path)
+    lint_result = lint_validate(file_path)
+    correctness_result = correctness_validate(file_path)
+
+    all_passed = stdlib_result["passed"] and lint_result["passed"] and correctness_result["passed"]
+
+    return {
+        "all_passed": all_passed,
+        "file_path": file_path,
+        "stdlib": stdlib_result,
+        "lint": lint_result,
+        "correctness": correctness_result,
+    }
 
 
 def build_implementation_agent(
@@ -72,7 +85,7 @@ def build_implementation_agent(
 
     The loop contains:
     1. A drafter LlmAgent that generates algorithm code
-    2. A self-reviewer LlmAgent that validates and decides retry/exit
+    2. A self-reviewer LlmAgent that validates with a single composite tool
 
     Args:
         model: LiteLlm model instance for both sub-agents.
@@ -92,7 +105,7 @@ def build_implementation_agent(
         name="self_reviewer",
         model=model,
         instruction=_REVIEWER_INSTRUCTION,
-        tools=[save_code, lint_validate, correctness_validate, stdlib_check, exit_loop],
+        tools=[validate_implementation, exit_loop],
         output_key="review_feedback",
     )
 

--- a/src/apprentice/agents/review.py
+++ b/src/apprentice/agents/review.py
@@ -10,42 +10,33 @@ from typing import TYPE_CHECKING, Any
 from google.adk.agents import LlmAgent, LoopAgent
 from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
-from apprentice.validators.tools import consistency_validate, schema_validate
-
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
 
 _REVIEWER_INSTRUCTION = """\
 You are a quality reviewer for algorithm artifacts in the no-magic educational project.
-Your job is to validate all generated artifacts for consistency and schema compliance.
 
-The artifacts are available in the conversation history:
-- generated_code: the implementation source code
-- instrumented_code: the instrumented source code
-- manim_scene_code: the Manim visualization scene
-- anki_deck_content: the Anki flashcard CSV
+Call validate_artifacts with the artifact content from the conversation history:
+- implementation_code: the generated algorithm source code
+- instrumented_code: the instrumented source code (if available)
+- manim_scene_code: the Manim visualization scene (if available)
+- anki_deck_content: the Anki flashcard CSV (if available)
 
-Steps:
-1. Call save_artifacts to write all artifact content to temporary files.
-   Pass the generated code, instrumented code, manim scene, and anki deck content
-   from the conversation history.
-2. Use the returned file paths to call consistency_validate with the artifacts JSON.
-3. Call schema_validate with the same artifacts JSON.
+The tool saves all artifacts to disk and runs consistency + schema validators.
 
-If ALL validators pass (both return passed=true), call exit_loop to finish successfully.
-If any validator reports structural failures (severity="error"), compile detailed feedback
-describing what needs to be fixed.
+If the tool returns all_passed=true, call exit_loop immediately.
+If any validator failed, respond with a summary of the failures.
 """
 
 
-def save_artifacts(
+def validate_artifacts(
     implementation_code: str = "",
     instrumented_code: str = "",
     manim_scene_code: str = "",
     anki_deck_content: str = "",
     algorithm_name: str = "algorithm",
 ) -> dict[str, Any]:
-    """Save all artifact content to temporary files for validation.
+    """Save all artifacts and run consistency + schema validators in one call.
 
     Args:
         implementation_code: Python source code for the algorithm.
@@ -55,9 +46,10 @@ def save_artifacts(
         algorithm_name: Name used for temp file stems.
 
     Returns:
-        Dict with file paths and a pre-built artifacts_json string
-        ready to pass to consistency_validate and schema_validate.
+        Dict with 'all_passed' bool and per-validator results.
     """
+    from apprentice.validators.tools import consistency_validate, schema_validate
+
     tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
@@ -83,9 +75,17 @@ def save_artifacts(
         anki_path.write_text(anki_deck_content, encoding="utf-8")
         paths["anki_deck"] = str(anki_path)
 
+    artifacts_json = json.dumps(paths)
+    consistency_result = consistency_validate(artifacts_json)
+    schema_result = schema_validate(artifacts_json)
+
+    all_passed = consistency_result["passed"] and schema_result["passed"]
+
     return {
-        "paths": paths,
-        "artifacts_json": json.dumps(paths),
+        "all_passed": all_passed,
+        "consistency": consistency_result,
+        "schema": schema_result,
+        "artifact_paths": paths,
     }
 
 
@@ -95,8 +95,8 @@ def build_review_agent(
 ) -> LoopAgent:
     """Build an ADK LoopAgent for artifact review and validation.
 
-    Runs consistency and schema compliance validators, exits on pass,
-    compiles feedback on failure.
+    Uses a single composite validate_artifacts tool that saves files and
+    runs both consistency and schema validators in one call.
 
     Args:
         model: LiteLlm model instance.
@@ -109,7 +109,7 @@ def build_review_agent(
         name="reviewer",
         model=model,
         instruction=_REVIEWER_INSTRUCTION,
-        tools=[save_artifacts, consistency_validate, schema_validate, exit_loop],
+        tools=[validate_artifacts, exit_loop],
         output_key="review_verdict",
         description="Validates artifacts for consistency and schema compliance.",
     )

--- a/tests/test_implementation_agent.py
+++ b/tests/test_implementation_agent.py
@@ -40,7 +40,7 @@ class TestImplementationAgent:
         model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
         agent = build_implementation_agent(model)
         reviewer = next(a for a in agent.sub_agents if a.name == "self_reviewer")
-        assert len(reviewer.tools) >= 3
+        assert len(reviewer.tools) == 2
 
     def test_drafter_output_key(self) -> None:
         model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")


### PR DESCRIPTION
## Summary

Sequential tool chains caused 50+ LLM calls per algorithm — each tool decision was a separate LLM round-trip. Composite tools reduce reviewer iterations from 5+ calls to 2.

### Before (5+ LLM calls per reviewer iteration)
```
LLM → "call save_code" → result → LLM → "call stdlib_check" → result → LLM → "call lint_validate" → result → LLM → "call correctness_validate" → result → LLM → "call exit_loop"
```

### After (2 LLM calls per reviewer iteration)
```
LLM → "call validate_implementation" → result → LLM → "call exit_loop"
```

## Changes

- `validate_implementation(code)`: saves code to temp file + runs stdlib_check + lint_validate + correctness_validate, returns combined `all_passed` + per-validator results
- `validate_artifacts(impl, instr, manim, anki)`: saves all artifacts to temp files + runs consistency_validate + schema_validate, returns combined `all_passed`
- Reviewer instructions simplified to 2-step: call composite tool → decide exit/retry

## Test plan
- [x] 249 tests passing, ruff clean, mypy --strict clean