### PR TITLE
fix: end-to-end pipeline execution with callback validation, Runner, claude_cli, and cost tracking

### DIFF
--- a/src/apprentice/agents/implementation.py
+++ b/src/apprentice/agents/implementation.py
@@ -1,4 +1,4 @@
-"""Implementation Agent — ADK LoopAgent with drafter + self-reviewer."""
+"""Implementation Agent — ADK LoopAgent with LLM drafter + programmatic validation."""
 
 from __future__ import annotations
 
@@ -7,53 +7,31 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from google.adk.agents import LlmAgent, LoopAgent
-from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
 
 _DRAFTER_INSTRUCTION = """\
 You are an expert algorithm implementer for the no-magic educational project.
-You write clean, well-documented Python implementations with:
+
+Write a complete Python implementation with:
+- Module-level docstring with summary, Args, Returns, Complexity, References sections
 - Type hints on all function signatures
-- Google-style docstrings with Args, Returns, Complexity sections
+- Google-style docstrings on all public functions
 - Zero external dependencies (stdlib only)
 - Inline comments explaining key algorithmic decisions
-- Reference test cases in an `if __name__ == "__main__":` block
+- Test assertions in an `if __name__ == "__main__":` block
 
-Generate the algorithm implementation based on the task description.
-If the conversation history contains feedback from a previous review,
-fix ALL listed issues in your new implementation.
+If the session state contains validation_feedback, your previous attempt failed.
+Fix ALL issues listed in the feedback.
 
 Write the complete Python source code. Do NOT use markdown fences.
 Write ONLY the Python source code, nothing else.
 """
 
-_REVIEWER_INSTRUCTION = """\
-You are a code reviewer for algorithm implementations.
 
-Call validate_implementation with the COMPLETE Python source code from the \
-drafter's previous message. The tool saves the code to disk and runs all \
-validators (stdlib-only imports, lint, correctness) in one step.
-
-If the tool returns all_passed=true, call exit_loop immediately.
-If any validator failed, respond with a summary of the failures for the drafter.
-"""
-
-
-def validate_implementation(code: str, algorithm_name: str = "algorithm") -> dict[str, Any]:
-    """Save code to disk and run all validators in a single call.
-
-    Writes the code to a temp file, then runs stdlib check, lint validation,
-    and correctness validation. Returns combined results.
-
-    Args:
-        code: Complete Python source code to validate.
-        algorithm_name: Name for the temp file (default: "algorithm").
-
-    Returns:
-        Dict with 'all_passed' bool, 'file_path', and per-validator results.
-    """
+def _run_validators(code: str, algorithm_name: str) -> dict[str, Any]:
+    """Run all validators on code and return combined results."""
     from apprentice.validators.tools import correctness_validate, lint_validate, stdlib_check
 
     tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
@@ -68,27 +46,108 @@ def validate_implementation(code: str, algorithm_name: str = "algorithm") -> dic
 
     all_passed = stdlib_result["passed"] and lint_result["passed"] and correctness_result["passed"]
 
+    failures: list[str] = []
+    if not stdlib_result["passed"]:
+        violations = stdlib_result.get("violations", [])
+        failures.append(f"Non-stdlib imports: {violations}")
+    if not lint_result["passed"]:
+        for issue in lint_result.get("issues", []):
+            failures.append(f"Lint: {issue.get('message', '')} — {issue.get('suggestion', '')}")
+    if not correctness_result["passed"]:
+        for issue in correctness_result.get("issues", []):
+            failures.append(
+                f"Correctness: {issue.get('message', '')} — {issue.get('suggestion', '')}"
+            )
+
     return {
         "all_passed": all_passed,
         "file_path": file_path,
-        "stdlib": stdlib_result,
-        "lint": lint_result,
-        "correctness": correctness_result,
+        "failures": failures,
     }
+
+
+def _make_after_drafter_callback() -> Any:
+    """Create a callback that validates the drafter's output after each generation.
+
+    If validation passes, sets _implementation_passed=True in state so the
+    LoopAgent's exit condition (checked via a trivial checker agent) fires.
+    If validation fails, writes feedback to session state for the next iteration.
+    """
+
+    async def after_drafter(callback_context: Any) -> Any:
+        state = callback_context.state
+        code = state.get("generated_code", "")
+        algorithm_name = state.get("algorithm_name", "algorithm")
+
+        if not code:
+            state["validation_feedback"] = (
+                "No code was generated. Write complete Python source code."
+            )
+            return None
+
+        result = _run_validators(code, algorithm_name)
+
+        if result["all_passed"]:
+            state["validation_feedback"] = ""
+            state["implementation_path"] = result["file_path"]
+        else:
+            feedback = "Your implementation has the following issues:\n"
+            feedback += "\n".join(f"- {f}" for f in result["failures"])
+            feedback += "\n\nFix ALL issues and rewrite the complete implementation."
+            state["validation_feedback"] = feedback
+
+        return None
+
+    return after_drafter
+
+
+def _make_exit_condition() -> Any:
+    """Create a callback that exits the loop when validation passes.
+
+    Checked before each iteration. If validation_feedback is empty (meaning
+    the previous iteration passed), exits the loop.
+    """
+
+    async def should_exit(callback_context: Any) -> Any:
+        from google.genai import types
+
+        state = callback_context.state
+        feedback = state.get("validation_feedback")
+
+        # On first iteration, validation_feedback doesn't exist yet — continue
+        if feedback is None:
+            return None
+
+        # Empty feedback means validation passed — exit
+        if feedback == "":
+            return types.Content(
+                role="model",
+                parts=[types.Part(text="Implementation validated successfully.")],
+            )
+
+        # Non-empty feedback means validation failed — continue loop
+        return None
+
+    return should_exit
 
 
 def build_implementation_agent(
     model: LiteLlm,
     max_retries: int = 3,
 ) -> LoopAgent:
-    """Build an ADK LoopAgent for algorithm implementation with self-validation.
+    """Build an ADK LoopAgent for algorithm implementation with programmatic validation.
 
-    The loop contains:
-    1. A drafter LlmAgent that generates algorithm code
-    2. A self-reviewer LlmAgent that validates with a single composite tool
+    Architecture:
+    - Single LlmAgent (drafter) generates code. 1 LLM call per iteration.
+    - after_agent_callback runs validators programmatically (no LLM needed).
+    - If validation fails, feedback is written to session state.
+    - The drafter reads {validation_feedback} on the next iteration.
+    - before_agent_callback on the LoopAgent exits when validation passes.
+
+    This uses 1 LLM call per iteration instead of 5+ with an LLM reviewer.
 
     Args:
-        model: LiteLlm model instance for both sub-agents.
+        model: LiteLlm model instance.
         max_retries: Maximum loop iterations before giving up.
 
     Returns:
@@ -99,19 +158,13 @@ def build_implementation_agent(
         model=model,
         instruction=_DRAFTER_INSTRUCTION,
         output_key="generated_code",
-    )
-
-    reviewer = LlmAgent(
-        name="self_reviewer",
-        model=model,
-        instruction=_REVIEWER_INSTRUCTION,
-        tools=[validate_implementation, exit_loop],
-        output_key="review_feedback",
+        after_agent_callback=_make_after_drafter_callback(),
     )
 
     return LoopAgent(
         name="implementation_loop",
-        description="Iteratively generates and validates algorithm implementations.",
+        description="Generates and validates algorithm implementations.",
         max_iterations=max_retries,
-        sub_agents=[drafter, reviewer],
+        sub_agents=[drafter],
+        before_agent_callback=_make_exit_condition(),
     )

--- a/src/apprentice/agents/review.py
+++ b/src/apprentice/agents/review.py
@@ -1,4 +1,10 @@
-"""Review Agent — ADK LoopAgent that validates all artifacts for consistency and schema."""
+"""Review Agent — programmatic artifact validation via ADK callbacks.
+
+No LLM is used for review — consistency and schema validators run
+as pure Python in an after_agent_callback. The LoopAgent iterates
+only if validation fails and there's a preceding agent to fix artifacts.
+Since artifact agents don't retry, this effectively runs once.
+"""
 
 from __future__ import annotations
 
@@ -8,115 +14,115 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from google.adk.agents import LlmAgent, LoopAgent
-from google.adk.tools import exit_loop  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from google.adk.models.lite_llm import LiteLlm
 
-_REVIEWER_INSTRUCTION = """\
-You are a quality reviewer for algorithm artifacts in the no-magic educational project.
 
-Call validate_artifacts with the artifact content from the conversation history:
-- implementation_code: the generated algorithm source code
-- instrumented_code: the instrumented source code (if available)
-- manim_scene_code: the Manim visualization scene (if available)
-- anki_deck_content: the Anki flashcard CSV (if available)
-
-The tool saves all artifacts to disk and runs consistency + schema validators.
-
-If the tool returns all_passed=true, call exit_loop immediately.
-If any validator failed, respond with a summary of the failures.
-"""
-
-
-def validate_artifacts(
-    implementation_code: str = "",
-    instrumented_code: str = "",
-    manim_scene_code: str = "",
-    anki_deck_content: str = "",
-    algorithm_name: str = "algorithm",
-) -> dict[str, Any]:
-    """Save all artifacts and run consistency + schema validators in one call.
-
-    Args:
-        implementation_code: Python source code for the algorithm.
-        instrumented_code: Python source with trace hooks.
-        manim_scene_code: Manim Scene Python source.
-        anki_deck_content: CSV content for Anki flashcards.
-        algorithm_name: Name used for temp file stems.
-
-    Returns:
-        Dict with 'all_passed' bool and per-validator results.
-    """
+def _validate_all_artifacts(state: dict[str, Any]) -> dict[str, Any]:
+    """Run consistency and schema validators on all artifacts in session state."""
     from apprentice.validators.tools import consistency_validate, schema_validate
 
+    algorithm_name = state.get("algorithm_name", "algorithm")
     tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     paths: dict[str, str] = {}
 
-    if implementation_code:
-        impl_path = tmp_dir / f"{algorithm_name}.py"
-        impl_path.write_text(implementation_code, encoding="utf-8")
-        paths["implementation"] = str(impl_path)
+    impl_code = state.get("generated_code", "")
+    if impl_code:
+        p = tmp_dir / f"{algorithm_name}.py"
+        p.write_text(impl_code, encoding="utf-8")
+        paths["implementation"] = str(p)
 
-    if instrumented_code:
-        instr_path = tmp_dir / f"{algorithm_name}_instrumented.py"
-        instr_path.write_text(instrumented_code, encoding="utf-8")
-        paths["instrumented"] = str(instr_path)
+    instr_code = state.get("instrumented_code", "")
+    if instr_code:
+        p = tmp_dir / f"{algorithm_name}_instrumented.py"
+        p.write_text(instr_code, encoding="utf-8")
+        paths["instrumented"] = str(p)
 
-    if manim_scene_code:
-        manim_path = tmp_dir / f"{algorithm_name}_scene.py"
-        manim_path.write_text(manim_scene_code, encoding="utf-8")
-        paths["manim_scene"] = str(manim_path)
+    manim_code = state.get("manim_scene_code", "")
+    if manim_code:
+        p = tmp_dir / f"{algorithm_name}_scene.py"
+        p.write_text(manim_code, encoding="utf-8")
+        paths["manim_scene"] = str(p)
 
-    if anki_deck_content:
-        anki_path = tmp_dir / f"{algorithm_name}_cards.csv"
-        anki_path.write_text(anki_deck_content, encoding="utf-8")
-        paths["anki_deck"] = str(anki_path)
+    anki_content = state.get("anki_deck_content", "")
+    if anki_content:
+        p = tmp_dir / f"{algorithm_name}_cards.csv"
+        p.write_text(anki_content, encoding="utf-8")
+        paths["anki_deck"] = str(p)
+
+    if not paths:
+        return {
+            "all_passed": False,
+            "failures": ["No artifacts found in session state"],
+            "artifact_paths": {},
+        }
 
     artifacts_json = json.dumps(paths)
-    consistency_result = consistency_validate(artifacts_json)
-    schema_result = schema_validate(artifacts_json)
+    consistency = consistency_validate(artifacts_json)
+    schema = schema_validate(artifacts_json)
 
-    all_passed = consistency_result["passed"] and schema_result["passed"]
+    all_passed = consistency["passed"] and schema["passed"]
 
-    return {
-        "all_passed": all_passed,
-        "consistency": consistency_result,
-        "schema": schema_result,
-        "artifact_paths": paths,
-    }
+    failures: list[str] = []
+    for result in (consistency, schema):
+        for issue in result.get("issues", []):
+            if issue.get("severity") == "error":
+                failures.append(f"{issue.get('artifact', '')}: {issue.get('message', '')}")
+
+    return {"all_passed": all_passed, "failures": failures, "artifact_paths": paths}
 
 
 def build_review_agent(
     model: LiteLlm,
     max_iterations: int = 2,
 ) -> LoopAgent:
-    """Build an ADK LoopAgent for artifact review and validation.
+    """Build a review stage that validates artifacts programmatically.
 
-    Uses a single composite validate_artifacts tool that saves files and
-    runs both consistency and schema validators in one call.
+    Uses a no-op LlmAgent as a placeholder inside a LoopAgent.
+    The before_agent_callback runs validators and either exits (pass)
+    or continues with feedback (fail). No LLM calls are made.
 
     Args:
-        model: LiteLlm model instance.
+        model: LiteLlm model instance (used for the placeholder agent).
         max_iterations: Maximum review rounds.
 
     Returns:
         A configured LoopAgent.
     """
-    reviewer = LlmAgent(
+
+    async def review_callback(callback_context: Any) -> Any:
+        from google.genai import types
+
+        state = callback_context.state
+        result = _validate_all_artifacts(state)
+
+        if result["all_passed"]:
+            state["review_verdict"] = "passed"
+            return types.Content(
+                role="model",
+                parts=[types.Part(text="All artifacts validated successfully.")],
+            )
+
+        state["review_verdict"] = "failed: " + "; ".join(result["failures"])
+        return types.Content(
+            role="model",
+            parts=[types.Part(text="Review: " + "; ".join(result["failures"]))],
+        )
+
+    placeholder = LlmAgent(
         name="reviewer",
         model=model,
-        instruction=_REVIEWER_INSTRUCTION,
-        tools=[validate_artifacts, exit_loop],
+        instruction="Artifacts are validated automatically.",
         output_key="review_verdict",
-        description="Validates artifacts for consistency and schema compliance.",
     )
 
     return LoopAgent(
         name="review_loop",
-        description="Iteratively reviews artifacts until all validators pass.",
+        description="Validates all artifacts for consistency and schema compliance.",
         max_iterations=max_iterations,
-        sub_agents=[reviewer],
+        sub_agents=[placeholder],
+        before_agent_callback=review_callback,
     )

--- a/src/apprentice/cli.py
+++ b/src/apprentice/cli.py
@@ -252,19 +252,27 @@ async def _run_pipeline_with_progress(
     description: str,
     progress: Any,
 ) -> dict[str, Any]:
-    """Run the ADK pipeline with optional progress tracking."""
-    from google.adk.agents import InvocationContext, RunConfig
+    """Run the ADK pipeline via Runner with optional progress tracking."""
+    from google.adk.agents import RunConfig
     from google.adk.artifacts import InMemoryArtifactService
-    from google.adk.events.event import Event
+    from google.adk.runners import Runner
     from google.adk.sessions import InMemorySessionService
     from google.genai import types
 
     session_service = InMemorySessionService()  # type: ignore[no-untyped-call]
     artifact_service = InMemoryArtifactService()
 
+    runner = Runner(
+        agent=pipeline,
+        app_name="apprentice",
+        session_service=session_service,
+        artifact_service=artifact_service,
+    )
+
+    user_id = "cli"
     session = await session_service.create_session(
         app_name="apprentice",
-        user_id="cli",
+        user_id=user_id,
         state={
             "algorithm_name": algorithm,
             "algorithm_tier": tier,
@@ -272,7 +280,7 @@ async def _run_pipeline_with_progress(
         },
     )
 
-    user_content = types.Content(
+    user_message = types.Content(
         role="user",
         parts=[
             types.Part(
@@ -284,74 +292,73 @@ async def _run_pipeline_with_progress(
         ],
     )
 
-    user_event = Event(
-        invocation_id="build_001",
-        author="user",
-        content=user_content,
-    )
-    session.events.append(user_event)
-
-    ctx = InvocationContext(
-        invocation_id="build_001",
-        agent=pipeline,
-        session=session,
-        session_service=session_service,
-        artifact_service=artifact_service,
-        run_config=RunConfig(max_llm_calls=50),
-    )
+    run_config = RunConfig(max_llm_calls=50)
 
     if progress is not None:
         with progress.start():
-            async for event in pipeline.run_async(ctx):
+            async for event in runner.run_async(
+                user_id=user_id,
+                session_id=session.id,
+                new_message=user_message,
+                run_config=run_config,
+            ):
                 progress.on_event(event)
     else:
-        async for _event in pipeline.run_async(ctx):
+        async for _event in runner.run_async(
+            user_id=user_id,
+            session_id=session.id,
+            new_message=user_message,
+            run_config=run_config,
+        ):
             pass
 
-    return dict(session.state)
+    updated_session = await session_service.get_session(
+        app_name="apprentice", user_id=user_id, session_id=session.id
+    )
+    return dict(updated_session.state) if updated_session else {}
 
 
 async def _run_agent(agent: Any, prompt: str) -> dict[str, Any]:
-    """Run a single ADK agent and return session state."""
-    from google.adk.agents import InvocationContext, RunConfig
+    """Run a single ADK agent via Runner and return session state."""
+    from google.adk.agents import RunConfig
     from google.adk.artifacts import InMemoryArtifactService
-    from google.adk.events.event import Event
+    from google.adk.runners import Runner
     from google.adk.sessions import InMemorySessionService
     from google.genai import types
 
     session_service = InMemorySessionService()  # type: ignore[no-untyped-call]
     artifact_service = InMemoryArtifactService()
 
-    session = await session_service.create_session(
+    runner = Runner(
+        agent=agent,
         app_name="apprentice",
-        user_id="cli",
+        session_service=session_service,
+        artifact_service=artifact_service,
     )
 
-    user_content = types.Content(
+    user_id = "cli"
+    session = await session_service.create_session(
+        app_name="apprentice",
+        user_id=user_id,
+    )
+
+    user_message = types.Content(
         role="user",
         parts=[types.Part(text=prompt)],
     )
 
-    user_event = Event(
-        invocation_id="run_001",
-        author="user",
-        content=user_content,
-    )
-    session.events.append(user_event)
-
-    ctx = InvocationContext(
-        invocation_id="run_001",
-        agent=agent,
-        session=session,
-        session_service=session_service,
-        artifact_service=artifact_service,
+    async for _event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=user_message,
         run_config=RunConfig(max_llm_calls=30),
-    )
-
-    async for _event in agent.run_async(ctx):
+    ):
         pass
 
-    return dict(session.state)
+    updated_session = await session_service.get_session(
+        app_name="apprentice", user_id=user_id, session_id=session.id
+    )
+    return dict(updated_session.state) if updated_session else {}
 
 
 def _cmd_preview() -> int:

--- a/src/apprentice/core/budget.py
+++ b/src/apprentice/core/budget.py
@@ -128,19 +128,53 @@ def make_before_agent_callback(
 
 def make_after_agent_callback(
     tracker: BudgetTracker,
+    model_name: str = "",
 ) -> Any:
     """Create an ADK after_agent_callback that tracks cost after completion.
 
+    Estimates token usage from session state content using tiktoken.
+
     Args:
         tracker: Budget tracker instance.
+        model_name: Model identifier for cost estimation.
 
     Returns:
         An async callback function compatible with ADK agent callbacks.
     """
+    _output_keys = frozenset(
+        {
+            "generated_code",
+            "instrumented_code",
+            "manim_scene_code",
+            "anki_deck_content",
+            "review_feedback",
+            "review_verdict",
+            "discovery_candidates",
+        }
+    )
+
+    _seen_keys: set[str] = set()
 
     async def after_agent_track_cost(callback_context: Any) -> Any:
+        from apprentice.core.tokens import estimate_cost
+
         agent_name = getattr(callback_context, "agent_name", "unknown")
-        tracker.record_agent_completion(agent_name)
+        state = getattr(callback_context, "state", {})
+
+        tokens = 0
+        cost = 0.0
+
+        for key in _output_keys:
+            if key in _seen_keys:
+                continue
+            value = state.get(key, "")
+            if value:
+                _seen_keys.add(key)
+                est = estimate_cost("", str(value), model_name)
+                tokens += est["output_tokens"]
+                cost += est["cost_usd"]
+
+        tracker.record_agent_completion(agent_name, tokens=tokens, cost=cost)
 
         _logger.info(
             "agent_completed",

--- a/src/apprentice/core/orchestrator.py
+++ b/src/apprentice/core/orchestrator.py
@@ -83,7 +83,9 @@ def build_pipeline(
         description="Full apprentice pipeline: implement → generate artifacts → review → package.",
         sub_agents=sub_agents,
         before_agent_callback=make_before_agent_callback(tracker),
-        after_agent_callback=make_after_agent_callback(tracker),
+        after_agent_callback=make_after_agent_callback(
+            tracker, model_name=getattr(model, "model", "")
+        ),
     )
 
 

--- a/src/apprentice/core/progress.py
+++ b/src/apprentice/core/progress.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
 from typing import Any
 
@@ -35,9 +36,23 @@ _PIPELINE_STAGES = [
 
 
 def suppress_noisy_loggers() -> None:
-    """Suppress LiteLLM, httpx, and other verbose loggers."""
+    """Suppress LiteLLM, httpx, and other verbose loggers.
+
+    Also removes stderr handlers from the root logger so Rich progress
+    display isn't interleaved with log lines. File handler is preserved
+    for structured JSON logs.
+    """
     for name in ("LiteLLM", "litellm", "httpx", "httpcore", "openai", "anthropic"):
         logging.getLogger(name).setLevel(logging.WARNING)
+
+    root = logging.getLogger()
+    root.handlers = [
+        h
+        for h in root.handlers
+        if not isinstance(h, logging.StreamHandler)
+        or not hasattr(h, "stream")
+        or h.stream is not sys.stderr
+    ]
 
 
 class PipelineProgress:

--- a/src/apprentice/core/tokens.py
+++ b/src/apprentice/core/tokens.py
@@ -1,0 +1,75 @@
+"""Token estimation for cost tracking across providers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import tiktoken
+
+_ENCODER = tiktoken.get_encoding("cl100k_base")
+
+# USD per 1M tokens: (input, output)
+_PRICING: dict[str, tuple[float, float]] = {
+    "claude-sonnet-4-6": (3.0, 15.0),
+    "claude-sonnet-4-20250514": (3.0, 15.0),
+    "claude-haiku-4-5": (0.80, 4.0),
+    "claude-haiku-4-5-20251001": (0.80, 4.0),
+    "claude-opus-4-6": (15.0, 75.0),
+    "gpt-4.1": (2.0, 8.0),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-5": (10.0, 30.0),
+    "gpt-5-mini": (1.10, 4.40),
+}
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens in text using tiktoken cl100k_base encoding.
+
+    Args:
+        text: Text to count tokens for.
+
+    Returns:
+        Token count.
+    """
+    return len(_ENCODER.encode(text))
+
+
+def estimate_cost(
+    input_text: str,
+    output_text: str,
+    model: str,
+) -> dict[str, Any]:
+    """Estimate token counts and cost for an LLM call.
+
+    Uses tiktoken for accurate token counting and model-specific pricing.
+    Falls back to character-based estimation for unknown models.
+
+    Args:
+        input_text: The prompt sent to the model.
+        output_text: The response from the model.
+        model: Model identifier (e.g. "claude-sonnet-4-6", "gpt-5-mini").
+
+    Returns:
+        Dict with input_tokens, output_tokens, total_tokens, and cost_usd.
+    """
+    input_tokens = count_tokens(input_text)
+    output_tokens = count_tokens(output_text)
+    total_tokens = input_tokens + output_tokens
+
+    # Strip provider prefix for pricing lookup
+    model_key = model.split("/")[-1] if "/" in model else model
+
+    pricing = _PRICING.get(model_key)
+    if pricing:
+        input_rate, output_rate = pricing
+        cost = (input_tokens * input_rate + output_tokens * output_rate) / 1_000_000
+    else:
+        # Unknown model — use a conservative estimate ($5/M input, $15/M output)
+        cost = (input_tokens * 5.0 + output_tokens * 15.0) / 1_000_000
+
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "cost_usd": round(cost, 6),
+    }

--- a/src/apprentice/providers/claude_cli.py
+++ b/src/apprentice/providers/claude_cli.py
@@ -1,0 +1,106 @@
+"""Claude CLI model — wraps `claude -p` as an ADK-compatible model.
+
+Uses the Claude Code CLI subscription instead of a direct API key.
+Text-only: supports generation agents but not tool-calling agents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import TYPE_CHECKING
+
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from google.adk.models.llm_request import LlmRequest
+
+
+class ClaudeCli(BaseLlm):
+    """ADK model that calls `claude -p --no-session-persistence` via subprocess.
+
+    Converts LlmRequest contents to a text prompt, runs the CLI, and wraps
+    the output in an LlmResponse. Supports text generation only — agents
+    with tool calling must use a different model.
+    """
+
+    model: str = "claude-cli"
+
+    def _build_command(self) -> list[str]:
+        """Build the claude CLI command with optional model flag."""
+        cmd = ["claude", "-p", "--no-session-persistence"]
+        if self.model and self.model != "claude-cli":
+            cmd.extend(["--model", self.model])
+        return cmd
+
+    def _contents_to_prompt(self, llm_request: LlmRequest) -> str:
+        """Extract a text prompt from LlmRequest contents."""
+        parts: list[str] = []
+
+        if llm_request.config and hasattr(llm_request.config, "system_instruction"):
+            si = llm_request.config.system_instruction
+            if si:
+                if isinstance(si, str):
+                    parts.append(f"[System]\n{si}\n")
+                elif hasattr(si, "parts") and si.parts:
+                    for p in si.parts:
+                        if hasattr(p, "text") and p.text:
+                            parts.append(f"[System]\n{p.text}\n")
+
+        for content in llm_request.contents or []:
+            role = getattr(content, "role", "user")
+            for part in getattr(content, "parts", []):
+                text = getattr(part, "text", None)
+                if text:
+                    parts.append(f"[{role}]\n{text}\n")
+
+        return "\n".join(parts)
+
+    async def generate_content_async(
+        self,
+        llm_request: LlmRequest,
+        stream: bool = False,
+    ) -> AsyncGenerator[LlmResponse, None]:
+        """Generate content by calling claude CLI.
+
+        Args:
+            llm_request: The ADK request with conversation contents.
+            stream: Ignored — CLI always returns complete responses.
+
+        Yields:
+            A single LlmResponse with the CLI output.
+        """
+        prompt = self._contents_to_prompt(llm_request)
+
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                self._build_command(),
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            output = result.stdout.strip()
+            if result.returncode != 0 and not output:
+                output = (
+                    f"Error: claude CLI returned code {result.returncode}: {result.stderr[:300]}"
+                )
+        except FileNotFoundError:
+            output = "Error: claude CLI not found. Install Claude Code: https://docs.anthropic.com/en/docs/claude-code"
+        except subprocess.TimeoutExpired:
+            output = "Error: claude CLI timed out after 300s"
+
+        response_content = types.Content(
+            role="model",
+            parts=[types.Part(text=output)],
+        )
+
+        yield LlmResponse(
+            content=response_content,
+            turn_complete=True,
+        )

--- a/src/apprentice/providers/factory.py
+++ b/src/apprentice/providers/factory.py
@@ -1,9 +1,9 @@
-"""LiteLlm model factory — creates ADK-compatible model instances from config."""
+"""Model factory — creates ADK-compatible model instances from config."""
 
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from google.adk.models.lite_llm import LiteLlm
 
@@ -17,25 +17,27 @@ _REQUIRED_ENV_VARS: dict[str, str | None] = {
     "gemini": "GOOGLE_API_KEY",
     "ollama": None,
     "local": None,
+    "claude_cli": None,
 }
 
 _SUPPORTED_BACKENDS = frozenset(_REQUIRED_ENV_VARS.keys())
 
 
-def create_model(config: ProviderConfig) -> LiteLlm:
-    """Create a LiteLlm model instance from apprentice config.
+def create_model(config: ProviderConfig) -> Any:
+    """Create an ADK-compatible model instance from apprentice config.
 
-    Supports backends: anthropic, openai, gemini, ollama, local (OpenAI-compatible).
+    Supports backends: anthropic, openai, gemini, ollama, local, claude_cli.
 
     For ollama: sets OLLAMA_API_BASE from config.local_api_base.
     For local: sets OPENAI_API_BASE and OPENAI_API_KEY=not-needed from config.
+    For claude_cli: uses `claude -p` subprocess (no API key needed).
     For cloud providers: reads API keys from environment variables.
 
     Args:
         config: Provider configuration from apprentice.toml.
 
     Returns:
-        A LiteLlm instance configured for the specified backend.
+        A LiteLlm or ClaudeCli instance configured for the specified backend.
 
     Raises:
         ValueError: If the backend is not supported.
@@ -47,6 +49,11 @@ def create_model(config: ProviderConfig) -> LiteLlm:
             f"Unsupported backend {backend!r}. Supported: {sorted(_SUPPORTED_BACKENDS)}"
         )
 
+    if backend == "claude_cli":
+        from apprentice.providers.claude_cli import ClaudeCli
+
+        return ClaudeCli(model=config.model or "claude-cli")
+
     _configure_environment(backend, config.local_api_base)
 
     return LiteLlm(model=config.model)
@@ -56,8 +63,8 @@ def create_model_from_override(
     model_string: str,
     backend: str,
     local_api_base: str = "",
-) -> LiteLlm:
-    """Create a LiteLlm model from CLI override flags.
+) -> Any:
+    """Create an ADK model from CLI override flags.
 
     Args:
         model_string: LiteLlm model string (e.g. "ollama_chat/llama3.3").
@@ -65,7 +72,7 @@ def create_model_from_override(
         local_api_base: API base URL for ollama/local backends.
 
     Returns:
-        A LiteLlm instance.
+        A LiteLlm or ClaudeCli instance.
 
     Raises:
         ValueError: If the backend is not supported.
@@ -75,6 +82,11 @@ def create_model_from_override(
         raise ValueError(
             f"Unsupported backend {backend!r}. Supported: {sorted(_SUPPORTED_BACKENDS)}"
         )
+
+    if backend == "claude_cli":
+        from apprentice.providers.claude_cli import ClaudeCli
+
+        return ClaudeCli(model=model_string or "claude-cli")
 
     _configure_environment(backend, local_api_base)
 

--- a/tests/test_adk_agents.py
+++ b/tests/test_adk_agents.py
@@ -41,15 +41,13 @@ class TestImplementationAgentBuilder:
         agent = build_implementation_agent(_model(), max_retries=5)
         assert agent.max_iterations == 5
 
-    def test_has_sub_agents(self) -> None:
+    def test_single_sub_agent(self) -> None:
         agent = build_implementation_agent(_model())
-        assert len(agent.sub_agents) == 2
+        assert len(agent.sub_agents) == 1
 
-    def test_sub_agent_names(self) -> None:
+    def test_drafter_name(self) -> None:
         agent = build_implementation_agent(_model())
-        names = [a.name for a in agent.sub_agents]
-        assert "drafter" in names
-        assert "self_reviewer" in names
+        assert agent.sub_agents[0].name == "drafter"
 
 
 class TestInstrumentationAgentBuilder:

--- a/tests/test_implementation_agent.py
+++ b/tests/test_implementation_agent.py
@@ -29,21 +29,30 @@ class TestImplementationAgent:
         agent = build_implementation_agent(model, max_retries=5)
         assert agent.max_iterations == 5
 
-    def test_has_drafter_and_reviewer(self) -> None:
+    def test_has_drafter(self) -> None:
         model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
         agent = build_implementation_agent(model)
         names = [a.name for a in agent.sub_agents]
         assert "drafter" in names
-        assert "self_reviewer" in names
 
-    def test_reviewer_has_tools(self) -> None:
+    def test_single_sub_agent(self) -> None:
         model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
         agent = build_implementation_agent(model)
-        reviewer = next(a for a in agent.sub_agents if a.name == "self_reviewer")
-        assert len(reviewer.tools) == 2
+        assert len(agent.sub_agents) == 1
 
     def test_drafter_output_key(self) -> None:
         model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
         agent = build_implementation_agent(model)
-        drafter = next(a for a in agent.sub_agents if a.name == "drafter")
+        drafter = agent.sub_agents[0]
         assert drafter.output_key == "generated_code"
+
+    def test_has_after_agent_callback(self) -> None:
+        model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
+        agent = build_implementation_agent(model)
+        drafter = agent.sub_agents[0]
+        assert drafter.after_agent_callback is not None
+
+    def test_has_before_agent_callback(self) -> None:
+        model = LiteLlm(model="anthropic/claude-sonnet-4-20250514")
+        agent = build_implementation_agent(model)
+        assert agent.before_agent_callback is not None


### PR DESCRIPTION
## Summary

Fixes the pipeline to run end-to-end successfully. Previously every integration test failed — 0% success rate across all providers. After these changes: **100% success rate on insertion_sort (tier 1) with claude-sonnet-4-6**.

Four root causes identified and fixed:

1. **LLM reviewers called tools in unbounded loops** — gpt-5-mini and gemma4 repeatedly invoked `validate_implementation` without calling `exit_loop`, exhausting the 50 LLM call limit every run. Fixed by replacing LLM reviewers with programmatic validation callbacks.

2. **Session state was empty after pipeline completion** — `agent.run_async(ctx)` yields events but never commits state deltas to the session service. `generated_code` was lost. Fixed by using ADK `Runner.run_async()` which processes events through the session service.

3. **No way to use Claude subscription** — required direct API keys. Added `claude_cli` backend that wraps `claude -p --no-session-persistence` as an ADK-compatible model.

4. **Cost always $0, noisy output** — budget callbacks never extracted token data; stderr log lines interleaved with Rich progress bar. Fixed with tiktoken estimation and stderr handler removal.

## Changes

### Callback-Based Validation (`agents/implementation.py`, `agents/review.py`)

**Before**: `LoopAgent(drafter, self_reviewer)` where self_reviewer was an LlmAgent with tools (`validate_implementation`, `exit_loop`). Each reviewer iteration cost 5+ LLM calls (decide tool → result → decide next tool → ...). Models called the same tool repeatedly without stopping.

**After**: `LoopAgent(drafter)` with:
- `after_agent_callback` on drafter: runs validators as Python (no LLM), writes feedback to session state
- `before_agent_callback` on LoopAgent: exits loop by returning `Content` when validation passes

**Result**: 1 LLM call per iteration instead of 5+. 3-iteration implementation loop costs 3 LLM calls instead of 50+.

Review agent: same pattern. `before_agent_callback` runs consistency + schema validators programmatically. 0 LLM calls for review. Fixed `KeyError: 'failures'` when no artifacts in session state.

### ADK Runner (`cli.py`)

**Before**: `async for event in pipeline.run_async(ctx): pass` — events yielded but state deltas not committed. `session.state` empty after completion.

**After**: `Runner(agent=pipeline, session_service=session_service).run_async(user_id, session_id, new_message)` — Runner processes events through session service. Final state read via `session_service.get_session()`.

Applied to both `_run_pipeline_with_progress` and `_run_agent`.

### Claude CLI Provider (`providers/claude_cli.py`, `providers/factory.py`)

New `ClaudeCli` class extending ADK `BaseLlm`:
- Converts `LlmRequest` contents to text prompt
- Calls `claude -p --no-session-persistence` via `asyncio.to_thread(subprocess.run, ...)`
- Wraps stdout in `LlmResponse` with `turn_complete=True`
- Supports `--model` flag: `--backend claude_cli --model claude-sonnet-4-6`
- 300s timeout, handles `FileNotFoundError` and `TimeoutExpired`

Factory updated: `claude_cli` added to supported backends, no API key required.

### Token Estimation (`core/tokens.py`, `core/budget.py`, `core/orchestrator.py`)

New `tokens.py`: tiktoken `cl100k_base` encoding with model-specific pricing:
- Claude Sonnet 4.6: $3/$15 per M tokens
- Claude Opus 4.6: $15/$75 per M tokens
- GPT-5-mini: $1.10/$4.40 per M tokens
- Unknown models: $5/$15 per M (conservative fallback)

`after_agent_callback` scans session state for new output keys (`generated_code`, `instrumented_code`, etc.), estimates tokens via tiktoken, accumulates in `BudgetTracker`.

### Clean Rich Output (`core/progress.py`)

`suppress_noisy_loggers()` now removes stderr handlers from the root logger. Log lines no longer interleave with the Rich progress bar. File handler preserved for structured JSON logs in `~/.apprentice/logs/`.

### Tests

Updated `test_implementation_agent.py` and `test_adk_agents.py` for new single-subagent architecture (drafter only, no self_reviewer). 251 tests passing.

## Verified

```
$ uv run python scripts/integration_test.py --backend claude_cli --model claude-sonnet-4-6 --tier 1 --limit 1
  Integration Test Results
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Metric         ┃   Value ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ Success Rate   │    100% │
│ Total Runs     │       1 │
│ Passed         │       1 │
└────────────────┴─────────┘
```

## Test plan
- [x] `uv run ruff check src/ tests/` — 0 errors
- [x] `uv run ruff format --check src/ tests/` — all formatted
- [x] `uv run mypy --strict src/apprentice/` — 0 errors
- [x] `uv run pytest tests/` — 251 passed
- [x] Integration test: insertion_sort tier 1 with claude-sonnet-4-6 — pass (563s)
- [ ] Integration test: multiple algorithms across tiers
- [ ] Integration test: with OpenAI backend