### PR TITLE
fix: wire gates into pipeline, per-stage observability, human-review guard

### DIFF
--- a/src/apprentice/agents/implementation.py
+++ b/src/apprentice/agents/implementation.py
@@ -13,20 +13,41 @@ if TYPE_CHECKING:
 
 _DRAFTER_INSTRUCTION = """\
 You are an expert algorithm implementer for the no-magic educational project.
+Every file you produce is reviewed against the no-magic house style; the
+commenting standard IS the primary merge criterion.
 
-Write a complete Python implementation with:
-- Module-level docstring with summary, Args, Returns, Complexity, References sections
-- Type hints on all function signatures
-- Google-style docstrings on all public functions
-- Zero external dependencies (stdlib only)
-- Inline comments explaining key algorithmic decisions
-- Test assertions in an `if __name__ == "__main__":` block
+# Hard requirements
 
-If the session state contains validation_feedback, your previous attempt failed.
-Fix ALL issues listed in the feedback.
+- Stdlib-only imports (`os`, `math`, `random`, `json`, `struct`, `urllib`,
+  `collections`, `itertools`, `functools`, `string`, `hashlib`, `time`,
+  `typing`, `dataclasses`). No third-party packages.
+- `from __future__ import annotations` enabled.
+- `random.seed(42)` is the first executable line after imports.
+- Runs under 10 minutes on laptop CPU with zero CLI arguments.
+- 4-space indentation, 100-char max line length.
 
-Write the complete Python source code. Do NOT use markdown fences.
-Write ONLY the Python source code, nothing else.
+# 7-point commenting standard (ALL required)
+
+1. File thesis docstring — one sentence stating what the script PROVES.
+2. Section headers — `# === SECTION NAME ===` between major phases
+   (imports → constants → data → model → training → inference/demo).
+3. Why comments — reasoning, not restatement.
+4. Math-to-code mappings — show the equation; name variable correspondences.
+5. Intuition comments — why the technique works.
+6. Signpost comments — flag every simplification; note the production
+   alternative.
+7. No obvious comments — every comment adds information the code doesn't
+   convey. Target 30-40% comment density.
+
+# __main__ block
+
+Minimum 3 assertions: normal case, edge case, stress case. Print a one-line
+pass summary on success.
+
+If session state contains `validation_feedback`, your previous attempt failed.
+Fix ALL listed issues.
+
+Return only the Python source code. No markdown fences, no prose.
 """
 
 

--- a/src/apprentice/cli.py
+++ b/src/apprentice/cli.py
@@ -49,6 +49,24 @@ def main(argv: list[str] | None = None) -> int:
     submit_parser.add_argument("--tier", type=int, default=2, help="Algorithm tier (default: 2)")
     submit_parser.add_argument("--backend", type=str, default=None, help="Override backend")
     submit_parser.add_argument("--model", type=str, default=None, help="Override model")
+    submit_parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help="Run ID whose approval authorizes this submit (from 'apprentice history')",
+    )
+
+    approve_parser = subparsers.add_parser(
+        "approve",
+        help="Record a human-review approval for a build run (required before submit)",
+    )
+    approve_parser.add_argument("run_id", help="Run ID to approve (from 'apprentice history')")
+    approve_parser.add_argument(
+        "--approver",
+        type=str,
+        default=None,
+        help="Approver identity (defaults to $GITHUB_USER or $USER)",
+    )
 
     suggest_parser = subparsers.add_parser("suggest", help="Discover candidate algorithms")
     suggest_parser.add_argument("--tier", type=int, default=2, help="Target tier (default: 2)")
@@ -86,6 +104,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_build(cfg, args)
     if args.command == "submit":
         return _cmd_submit(cfg, args)
+    if args.command == "approve":
+        return _cmd_approve(args)
     if args.command == "suggest":
         return _cmd_suggest(cfg, args)
     if args.command == "retry":
@@ -197,19 +217,136 @@ def _cmd_build(cfg: ApprenticeConfig, args: Any) -> int:
 def _cmd_submit(cfg: ApprenticeConfig, args: Any) -> int:
     from apprentice.core.observability import get_logger
     from apprentice.core.orchestrator import build_pipeline
+    from apprentice.core.session_store import SessionStore
 
     logger = get_logger(__name__)
-    logger.info("submit started: %s (tier %d)", args.algorithm, args.tier)
+    store = SessionStore()
+
+    run_id = args.run_id or _latest_completed_run_id(store, args.algorithm)
+    if run_id is None:
+        _print_json(
+            {
+                "error": (
+                    f"No completed build found for '{args.algorithm}'. "
+                    "Run 'apprentice build' first."
+                )
+            }
+        )
+        return 1
+
+    try:
+        record = store.load(run_id)
+    except FileNotFoundError:
+        _print_json({"error": f"Run not found: {run_id}"})
+        return 1
+
+    approval = record.session_state.get("review_approval") if record.session_state else None
+    if not approval:
+        _print_json(
+            {
+                "error": "no human-review approval recorded for this run",
+                "run_id": run_id,
+                "remediation": f"apprentice approve {run_id}",
+            }
+        )
+        return 1
+
+    logger.info("submit started: %s (tier %d, run %s)", args.algorithm, args.tier, run_id)
 
     model = _resolve_model(cfg, args)
-    pipeline = build_pipeline(model, cfg, include_packaging=True)
+    pipeline = build_pipeline(model, cfg, include_packaging=True, approval=approval)
 
     start = time.monotonic()
     session_state = asyncio.run(_run_pipeline(pipeline, args.algorithm, args.tier, ""))
     elapsed = time.monotonic() - start
 
-    _print_build_result(args.algorithm, args.tier, session_state, elapsed)
+    _print_build_result(args.algorithm, args.tier, session_state, elapsed, run_id)
     return 0
+
+
+def _cmd_approve(args: Any) -> int:
+    """Record a human-review approval for a completed build run."""
+    import os
+    from datetime import UTC, datetime
+
+    from apprentice.core.gate_agent import materialize_artifacts
+    from apprentice.core.session_store import SessionStore
+    from apprentice.gates.review import compute_artifact_hashes
+
+    store = SessionStore()
+
+    try:
+        record = store.load(args.run_id)
+    except FileNotFoundError:
+        _print_json({"error": f"Run not found: {args.run_id}"})
+        return 1
+
+    if record.status != "completed":
+        _print_json(
+            {
+                "error": (
+                    f"Run {args.run_id} is not completed "
+                    f"(status: {record.status}); nothing to approve."
+                )
+            }
+        )
+        return 1
+
+    approver = args.approver or os.environ.get("GITHUB_USER") or os.environ.get("USER") or ""
+    if not approver:
+        _print_json(
+            {
+                "error": (
+                    "cannot determine approver — pass --approver or set "
+                    "GITHUB_USER/USER environment variable."
+                )
+            }
+        )
+        return 1
+
+    bundle = materialize_artifacts(record.session_state or {})
+    hashes = compute_artifact_hashes(bundle)
+    if not hashes:
+        _print_json(
+            {
+                "error": (
+                    "no artifacts could be materialized from run state; "
+                    "rebuild before approving."
+                ),
+                "run_id": args.run_id,
+            }
+        )
+        return 1
+
+    approval = {
+        "approved_by": approver,
+        "approved_at": datetime.now(tz=UTC).isoformat(),
+        "run_id": args.run_id,
+        "artifact_hashes": hashes,
+    }
+
+    state = dict(record.session_state) if record.session_state else {}
+    state["review_approval"] = approval
+    record.session_state = state
+    store.save(record)
+
+    _print_json(
+        {
+            "approved": True,
+            "run_id": args.run_id,
+            "approved_by": approver,
+            "artifact_hashes": hashes,
+        }
+    )
+    return 0
+
+
+def _latest_completed_run_id(store: Any, algorithm: str) -> str | None:
+    """Return the most recent completed run_id for `algorithm`, or None."""
+    for record in store.list_runs(status="completed", limit=50):
+        if record.algorithm_name == algorithm:
+            return record.run_id
+    return None
 
 
 def _cmd_suggest(cfg: ApprenticeConfig, args: Any) -> int:

--- a/src/apprentice/core/budget.py
+++ b/src/apprentice/core/budget.py
@@ -20,7 +20,10 @@ class BudgetTracker:
         total_usd: Maximum USD allowed for the entire pipeline run.
         tokens_used: Running total of tokens consumed.
         cost_usd: Running total of USD spent.
-        per_agent: Per-agent token and cost breakdown.
+        per_agent: Per-agent token and cost breakdown, one entry per stage
+            name (e.g. `drafter`, `instrumentation`, `visualization`,
+            `assessment`, `reviewer`, `packaging`, plus gate agents).
+        gate_verdicts: Ordered list of gate results appended in execution order.
     """
 
     total_tokens: int
@@ -28,6 +31,7 @@ class BudgetTracker:
     tokens_used: int = 0
     cost_usd: float = 0.0
     per_agent: dict[str, dict[str, Any]] = field(default_factory=dict)
+    gate_verdicts: list[dict[str, Any]] = field(default_factory=list)
     _agent_start_times: dict[str, float] = field(default_factory=dict)
 
     @property
@@ -75,6 +79,23 @@ class BudgetTracker:
         entry["calls"] += 1
         entry["duration_seconds"] += duration
 
+    def record_gate_verdict(
+        self,
+        gate_name: str,
+        after_stage: str,
+        verdict: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a gate verdict in execution order."""
+        self.gate_verdicts.append(
+            {
+                "gate_name": gate_name,
+                "after_stage": after_stage,
+                "verdict": verdict,
+                "diagnostics": diagnostics or {},
+            }
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "total_tokens": self.total_tokens,
@@ -84,20 +105,26 @@ class BudgetTracker:
             "tokens_remaining": self.tokens_remaining,
             "usd_remaining": round(self.usd_remaining, 6),
             "per_agent": self.per_agent,
+            "gate_verdicts": self.gate_verdicts,
         }
+
+
+_OUTPUT_KEY_BY_AGENT: dict[str, str] = {
+    "drafter": "generated_code",
+    "instrumentation": "instrumented_code",
+    "visualization": "manim_scene_code",
+    "assessment": "anki_deck_content",
+    "reviewer": "review_verdict",
+    "review_loop": "review_verdict",
+    "packaging": "pr_urls",
+    "discovery": "discovery_candidates",
+}
 
 
 def make_before_agent_callback(
     tracker: BudgetTracker,
 ) -> Any:
-    """Create an ADK before_agent_callback that checks budget before dispatch.
-
-    Args:
-        tracker: Budget tracker instance.
-
-    Returns:
-        An async callback function compatible with ADK agent callbacks.
-    """
+    """Create an ADK before_agent_callback that checks budget before dispatch."""
 
     async def before_agent_budget_check(callback_context: Any) -> Any:
         agent_name = getattr(callback_context, "agent_name", "unknown")
@@ -132,27 +159,10 @@ def make_after_agent_callback(
 ) -> Any:
     """Create an ADK after_agent_callback that tracks cost after completion.
 
-    Estimates token usage from session state content using tiktoken.
-
-    Args:
-        tracker: Budget tracker instance.
-        model_name: Model identifier for cost estimation.
-
-    Returns:
-        An async callback function compatible with ADK agent callbacks.
+    Attributes the most recent unattributed output key (per `_OUTPUT_KEY_BY_AGENT`)
+    to the agent that just finished, so each stage gets its own token/cost row
+    rather than everything collapsing into the pipeline root.
     """
-    _output_keys = frozenset(
-        {
-            "generated_code",
-            "instrumented_code",
-            "manim_scene_code",
-            "anki_deck_content",
-            "review_feedback",
-            "review_verdict",
-            "discovery_candidates",
-        }
-    )
-
     _seen_keys: set[str] = set()
 
     async def after_agent_track_cost(callback_context: Any) -> Any:
@@ -164,12 +174,11 @@ def make_after_agent_callback(
         tokens = 0
         cost = 0.0
 
-        for key in _output_keys:
-            if key in _seen_keys:
-                continue
-            value = state.get(key, "")
+        expected_key = _OUTPUT_KEY_BY_AGENT.get(agent_name)
+        if expected_key and expected_key not in _seen_keys:
+            value = state.get(expected_key, "")
             if value:
-                _seen_keys.add(key)
+                _seen_keys.add(expected_key)
                 est = estimate_cost("", str(value), model_name)
                 tokens += est["output_tokens"]
                 cost += est["cost_usd"]
@@ -189,17 +198,28 @@ def make_after_agent_callback(
     return after_agent_track_cost
 
 
+def wire_agent_callbacks(agent: Any, tracker: BudgetTracker, model_name: str) -> None:
+    """Attach budget callbacks to an agent and recursively to its sub-agents.
+
+    ADK fires agent-level callbacks only on the specific agent they are
+    attached to; a callback on a parent `SequentialAgent` does not fire per
+    sub-agent. To produce one `per_agent` row per stage we attach the same
+    tracker's callbacks to every node in the tree.
+    """
+    try:
+        agent.before_agent_callback = make_before_agent_callback(tracker)
+        agent.after_agent_callback = make_after_agent_callback(tracker, model_name)
+    except (AttributeError, ValueError):
+        pass
+
+    for sub in getattr(agent, "sub_agents", []) or []:
+        wire_agent_callbacks(sub, tracker, model_name)
+
+
 def make_before_model_callback(
     tracker: BudgetTracker,
 ) -> Any:
-    """Create an ADK before_model_callback for LLM request logging.
-
-    Args:
-        tracker: Budget tracker instance.
-
-    Returns:
-        An async callback function.
-    """
+    """Create an ADK before_model_callback for LLM request logging."""
 
     async def before_model_log(callback_context: Any, llm_request: Any) -> Any:
         _logger.debug(
@@ -214,14 +234,7 @@ def make_before_model_callback(
 def make_after_model_callback(
     tracker: BudgetTracker,
 ) -> Any:
-    """Create an ADK after_model_callback for LLM response token tracking.
-
-    Args:
-        tracker: Budget tracker instance.
-
-    Returns:
-        An async callback function.
-    """
+    """Create an ADK after_model_callback for LLM response token tracking."""
 
     async def after_model_log(callback_context: Any, llm_response: Any) -> Any:
         _logger.debug(

--- a/src/apprentice/core/gate_agent.py
+++ b/src/apprentice/core/gate_agent.py
@@ -1,0 +1,192 @@
+"""GateAgent — ADK BaseAgent wrapper that runs a gates/ check between stages.
+
+Bridges `apprentice.gates.base.GateInterface` implementations into the ADK
+`SequentialAgent` pipeline so deterministic post-stage gates actually fire at
+runtime. A blocking FAIL yields an event with `ctx.end_invocation = True`
+halting the pipeline.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from google.adk.agents import BaseAgent
+
+from apprentice.core.budget import BudgetTracker  # noqa: TC001 — pydantic needs at runtime
+from apprentice.core.observability import get_logger
+from apprentice.models.artifact import ArtifactBundle
+from apprentice.models.work_item import GateVerdict, WorkItem, WorkItemStatus
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events import Event
+
+    from apprentice.gates.base import GateInterface
+
+_logger = get_logger(__name__)
+
+
+def materialize_artifacts(state: dict[str, Any]) -> ArtifactBundle:
+    """Materialize session-state outputs to disk and populate an ArtifactBundle.
+
+    Gates expect on-disk paths (they exec files, parse CSVs, etc.). ADK stores
+    outputs as strings in session state, so the gate boundary is where we
+    persist them.
+    """
+    algorithm_name = state.get("algorithm_name", "algorithm")
+    tmp_dir = Path(tempfile.gettempdir()) / "apprentice_artifacts"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle = ArtifactBundle(id=algorithm_name, work_item_id=algorithm_name)
+
+    impl = state.get("generated_code", "")
+    if impl:
+        p = tmp_dir / f"{algorithm_name}.py"
+        p.write_text(impl, encoding="utf-8")
+        bundle.implementation_path = str(p)
+
+    instr = state.get("instrumented_code", "")
+    if instr:
+        p = tmp_dir / f"{algorithm_name}_instrumented.py"
+        p.write_text(instr, encoding="utf-8")
+        bundle.instrumented_path = str(p)
+
+    scene = state.get("manim_scene_code", "")
+    if scene:
+        p = tmp_dir / f"{algorithm_name}_scene.py"
+        p.write_text(scene, encoding="utf-8")
+        bundle.manim_scene_path = str(p)
+
+    anki = state.get("anki_deck_content", "")
+    if anki:
+        p = tmp_dir / f"{algorithm_name}_cards.csv"
+        p.write_text(anki, encoding="utf-8")
+        bundle.anki_deck_path = str(p)
+
+    return bundle
+
+
+def _work_item_from_state(state: dict[str, Any]) -> WorkItem:
+    """Build a WorkItem from session state for gate evaluation."""
+    return WorkItem(
+        id=str(state.get("algorithm_name", "algorithm")),
+        algorithm_name=str(state.get("algorithm_name", "algorithm")),
+        tier=int(state.get("algorithm_tier", 2)),
+        status=WorkItemStatus.IN_PROGRESS,
+    )
+
+
+class GateAgent(BaseAgent):
+    """ADK agent that runs a `GateInterface` as a deterministic pipeline gate.
+
+    On PASS it yields a small confirmation event and the pipeline continues.
+    On a blocking FAIL it sets `ctx.end_invocation = True` and yields a FAIL
+    event — downstream sub-agents will not run. WARN logs a warning and
+    continues.
+
+    Gate verdicts are recorded into `state['gate_verdicts']` (ordered list)
+    and into the shared `BudgetTracker` when one is provided.
+    """
+
+    model_config: ClassVar[dict[str, Any]] = {"arbitrary_types_allowed": True}
+
+    gate: Any
+    after_stage: str
+    tracker: BudgetTracker | None = None
+
+    def __init__(
+        self,
+        gate: GateInterface,
+        after_stage: str,
+        tracker: BudgetTracker | None = None,
+    ) -> None:
+        super().__init__(
+            name=f"gate_{gate.name}_after_{after_stage}",
+            description=f"Gate '{gate.name}' evaluated after stage '{after_stage}'.",
+            gate=gate,
+            after_stage=after_stage,
+            tracker=tracker,
+        )
+
+    async def _run_async_impl(
+        self, ctx: InvocationContext
+    ) -> AsyncGenerator[Event, None]:
+        from google.adk.events import Event
+        from google.genai import types
+
+        state = dict(ctx.session.state)
+        work_item = _work_item_from_state(state)
+        bundle = materialize_artifacts(state)
+
+        try:
+            result = self.gate.evaluate(work_item, bundle)
+            verdict_value = result.verdict.value
+            diagnostics = result.diagnostics
+        except Exception as exc:
+            _logger.exception(
+                "gate_exception",
+                extra={"gate_name": self.gate.name, "after_stage": self.after_stage},
+            )
+            verdict_value = GateVerdict.FAIL.value
+            diagnostics = {"error": f"gate raised: {exc}"}
+
+        verdict_entry = {
+            "gate_name": self.gate.name,
+            "after_stage": self.after_stage,
+            "verdict": verdict_value,
+            "diagnostics": diagnostics,
+        }
+
+        verdicts: list[dict[str, Any]] = list(ctx.session.state.get("gate_verdicts", []))
+        verdicts.append(verdict_entry)
+        ctx.session.state["gate_verdicts"] = verdicts
+
+        if self.tracker is not None:
+            self.tracker.record_gate_verdict(
+                gate_name=self.gate.name,
+                after_stage=self.after_stage,
+                verdict=verdict_value,
+                diagnostics=diagnostics,
+            )
+
+        is_blocking_fail = (
+            verdict_value == GateVerdict.FAIL.value and getattr(self.gate, "blocking", True)
+        )
+
+        if is_blocking_fail:
+            _logger.error(
+                "blocking_gate_failed",
+                extra={
+                    "gate_name": self.gate.name,
+                    "after_stage": self.after_stage,
+                    "diagnostics": diagnostics,
+                },
+            )
+            ctx.end_invocation = True
+            message = f"Gate '{self.gate.name}' FAILED after {self.after_stage}"
+        elif verdict_value == GateVerdict.WARN.value:
+            _logger.warning(
+                "gate_warning",
+                extra={
+                    "gate_name": self.gate.name,
+                    "after_stage": self.after_stage,
+                    "diagnostics": diagnostics,
+                },
+            )
+            message = f"Gate '{self.gate.name}' WARN after {self.after_stage}"
+        else:
+            message = f"Gate '{self.gate.name}' PASS after {self.after_stage}"
+
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=getattr(ctx, "branch", None),
+            content=types.Content(
+                role="model",
+                parts=[types.Part(text=message)],
+            ),
+        )

--- a/src/apprentice/core/orchestrator.py
+++ b/src/apprentice/core/orchestrator.py
@@ -19,7 +19,14 @@ from apprentice.core.budget import (
     BudgetTracker,
     make_after_agent_callback,
     make_before_agent_callback,
+    wire_agent_callbacks,
 )
+from apprentice.core.gate_agent import GateAgent
+from apprentice.gates.consistency import ConsistencyGate
+from apprentice.gates.correctness import CorrectnessGate
+from apprentice.gates.lint import LintGate
+from apprentice.gates.review import ReviewGate
+from apprentice.gates.schema_compliance import SchemaComplianceGate
 
 if TYPE_CHECKING:
     from apprentice.core.config import ApprenticeConfig
@@ -29,23 +36,33 @@ def build_pipeline(
     model: LiteLlm,
     config: ApprenticeConfig,
     include_packaging: bool = False,
+    approval: dict[str, Any] | None = None,
 ) -> SequentialAgent:
-    """Build the full ADK pipeline as a SequentialAgent.
+    """Build the full ADK pipeline as a SequentialAgent with gates between stages.
 
-    Pipeline structure:
-        1. Implementation (LoopAgent: drafter → self_reviewer, max 3 iterations)
-        2. Parallel artifact generation:
-           - Instrumentation (LlmAgent)
-           - Visualization (LlmAgent)
-           - Assessment (LlmAgent)
-        3. Review (LoopAgent: reviewer, max 2 iterations)
-        4. Packaging (LlmAgent, only when include_packaging=True)
+    Stage/gate ordering:
+        1. implementation_loop
+           → correctness gate (blocking)
+           → lint gate (blocking)
+        2. artifact_generation (instrumentation | visualization | assessment)
+           → consistency gate (blocking)
+           → schema_compliance gate (blocking)
+        3. review_loop
+        4. [submit only] review gate (human approval hard stop, blocking)
+        5. [submit only] packaging
+
+    Every sub-agent (and gate) gets the same shared `BudgetTracker` so the
+    run record reports per-stage token/cost rows (fixes #13 collapse into
+    a single `apprentice_pipeline` row) plus ordered gate verdicts.
 
     Args:
         model: LiteLlm model instance for all agents.
         config: Full apprentice configuration.
         include_packaging: Whether to include the packaging agent
-            (True for 'submit', False for 'build').
+            (True for `submit`, False for `build`).
+        approval: Human-review approval payload loaded from the run record.
+            Required when `include_packaging=True`; otherwise the review gate
+            fails and packaging never executes.
 
     Returns:
         A configured SequentialAgent representing the full pipeline.
@@ -55,32 +72,43 @@ def build_pipeline(
         total_usd=config.budget.cycle.max_cost_per_cycle_usd,
     )
 
+    implementation_agent = build_implementation_agent(
+        model,
+        max_retries=config.agents.max_implementation_retries,
+    )
+    artifact_parallel = ParallelAgent(
+        name="artifact_generation",
+        description="Generates instrumentation, visualization, and assessment artifacts concurrently.",
+        sub_agents=[
+            build_instrumentation_agent(model),
+            build_visualization_agent(model),
+            build_assessment_agent(model),
+        ],
+    )
+    review_agent = build_review_agent(
+        model,
+        max_iterations=config.agents.max_review_rounds,
+    )
+
     sub_agents: list[Any] = [
-        build_implementation_agent(
-            model,
-            max_retries=config.agents.max_implementation_retries,
-        ),
-        ParallelAgent(
-            name="artifact_generation",
-            description="Generates instrumentation, visualization, and assessment artifacts concurrently.",
-            sub_agents=[
-                build_instrumentation_agent(model),
-                build_visualization_agent(model),
-                build_assessment_agent(model),
-            ],
-        ),
-        build_review_agent(
-            model,
-            max_iterations=config.agents.max_review_rounds,
-        ),
+        implementation_agent,
+        GateAgent(CorrectnessGate(), after_stage="implementation", tracker=tracker),
+        GateAgent(LintGate(), after_stage="implementation", tracker=tracker),
+        artifact_parallel,
+        GateAgent(ConsistencyGate(), after_stage="artifact_generation", tracker=tracker),
+        GateAgent(SchemaComplianceGate(), after_stage="artifact_generation", tracker=tracker),
+        review_agent,
     ]
 
     if include_packaging:
+        sub_agents.append(
+            GateAgent(ReviewGate(approval=approval), after_stage="review", tracker=tracker),
+        )
         sub_agents.append(build_packaging_agent(model))
 
-    return SequentialAgent(
+    pipeline = SequentialAgent(
         name="apprentice_pipeline",
-        description="Full apprentice pipeline: implement → generate artifacts → review → package.",
+        description="Full apprentice pipeline: implement → gate → generate artifacts → gate → review → package.",
         sub_agents=sub_agents,
         before_agent_callback=make_before_agent_callback(tracker),
         after_agent_callback=make_after_agent_callback(
@@ -88,30 +116,22 @@ def build_pipeline(
         ),
     )
 
+    model_name = getattr(model, "model", "")
+    for sub in sub_agents:
+        wire_agent_callbacks(sub, tracker, model_name)
+
+    return pipeline
+
 
 def build_discovery_pipeline(model: LiteLlm) -> Any:
-    """Build a standalone discovery agent for the suggest command.
-
-    Args:
-        model: LiteLlm model instance.
-
-    Returns:
-        A configured discovery LlmAgent.
-    """
+    """Build a standalone discovery agent for the suggest command."""
     from apprentice.agents.discovery import build_discovery_agent
 
     return build_discovery_agent(model)
 
 
 def get_budget_tracker_from_pipeline(pipeline: SequentialAgent) -> BudgetTracker | None:
-    """Extract the BudgetTracker from a pipeline's callbacks.
-
-    Args:
-        pipeline: The pipeline SequentialAgent.
-
-    Returns:
-        The BudgetTracker if found, None otherwise.
-    """
+    """Extract the BudgetTracker from a pipeline's callbacks."""
     cb = pipeline.before_agent_callback
     if cb is not None and hasattr(cb, "__closure__") and cb.__closure__:
         for cell in cb.__closure__:

--- a/src/apprentice/core/session_store.py
+++ b/src/apprentice/core/session_store.py
@@ -145,6 +145,11 @@ class SessionStore:
                 break
         return records
 
+    def save(self, record: RunRecord) -> RunRecord:
+        """Persist an updated run record, preserving identity."""
+        self._write(record)
+        return record
+
     def delete(self, run_id: str) -> bool:
         """Delete a run record. Returns True if deleted, False if not found."""
         path = self._path_for(run_id)

--- a/src/apprentice/gates/review.py
+++ b/src/apprentice/gates/review.py
@@ -1,3 +1,122 @@
-"""Human review gate — PR submission with merge block enforcement."""
+"""Human review gate — blocks `submit` until an operator approves artifacts.
+
+Design (per issue #14):
+- After `build` produces artifacts, the run record carries `review_approval_required=True`.
+- `apprentice approve <run_id>` writes `review_approval` onto the run record,
+  including a per-artifact SHA-256 fingerprint.
+- This gate runs at the start of `submit` (before packaging) and FAILs when
+  either no approval exists or any artifact hash has changed since approval.
+
+The gate is pure; it reads approval metadata from the run record via the
+session-state key `review_approval` populated by the CLI before launching
+the submit pipeline. Any gate failure halts the pipeline before `open_pr`
+can run, so operators cannot accidentally publish unapproved artifacts.
+"""
 
 from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+
+def compute_artifact_hashes(bundle: ArtifactBundle) -> dict[str, str]:
+    """Return a dict of artifact_name -> sha256 hex digest for every present file."""
+    fields = {
+        "implementation": bundle.implementation_path,
+        "instrumented": bundle.instrumented_path,
+        "manim_scene": bundle.manim_scene_path,
+        "anki_deck": bundle.anki_deck_path,
+    }
+    hashes: dict[str, str] = {}
+    for name, path_str in fields.items():
+        if not path_str:
+            continue
+        path = Path(path_str)
+        if not path.exists():
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        hashes[name] = digest
+    return hashes
+
+
+class ReviewGate:
+    """Blocks `submit` unless a recorded approval matches current artifact hashes.
+
+    Approval payload (written by `apprentice approve`):
+        {
+            "approved_by": "<gh_login>",
+            "approved_at": "<iso8601>",
+            "run_id": "<run_id>",
+            "artifact_hashes": {"implementation": "<sha256>", ...}
+        }
+    """
+
+    name = "review"
+    max_retries = 0
+    blocking = True
+
+    def __init__(self, approval: dict[str, Any] | None = None) -> None:
+        self._approval = approval or {}
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        approval = self._approval
+        if not approval:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={
+                    "error": "no approval recorded",
+                    "remediation": (
+                        "Run `apprentice approve <run_id>` after manually "
+                        "reviewing generated artifacts, then re-run `submit`."
+                    ),
+                },
+            )
+
+        required_fields = ("approved_by", "approved_at", "artifact_hashes")
+        missing = [field for field in required_fields if field not in approval]
+        if missing:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={
+                    "error": f"approval payload is missing fields: {missing}",
+                    "approval": approval,
+                },
+            )
+
+        expected = approval.get("artifact_hashes", {})
+        current = compute_artifact_hashes(artifacts)
+        diffs = {
+            name: {"approved": expected.get(name, ""), "current": current.get(name, "")}
+            for name in set(expected) | set(current)
+            if expected.get(name) != current.get(name)
+        }
+
+        if diffs:
+            return GateResult(
+                gate_name=self.name,
+                verdict=GateVerdict.FAIL,
+                diagnostics={
+                    "error": "artifact hashes diverge from approval — re-approve required",
+                    "diffs": diffs,
+                    "approved_by": approval.get("approved_by", ""),
+                    "approved_at": approval.get("approved_at", ""),
+                },
+            )
+
+        return GateResult(
+            gate_name=self.name,
+            verdict=GateVerdict.PASS,
+            diagnostics={
+                "approved_by": approval.get("approved_by", ""),
+                "approved_at": approval.get("approved_at", ""),
+                "hashes_matched": sorted(current.keys()),
+            },
+        )

--- a/src/apprentice/prompts/implementation.yaml
+++ b/src/apprentice/prompts/implementation.yaml
@@ -1,15 +1,68 @@
 name: implementation
-version: "1.0.0"
-description: "Generates a single-file Python algorithm implementation"
+version: "2.0.0"
+description: "Generates a single-file Python algorithm implementation in the no-magic house style"
 
 system_prompt: |
   You are an expert algorithm implementer for the no-magic educational project.
-  You write clean, well-documented Python implementations with:
-  - Type hints on all function signatures
-  - Google-style docstrings with Args, Returns, Complexity sections
-  - Zero external dependencies (stdlib only)
-  - Inline comments explaining key algorithmic decisions
-  - Reference test cases as a __main__ block
+  Every script you write will be reviewed against the `no-magic` house style; the
+  commenting standard IS the primary merge criterion. Generic "clean educational
+  code" does not qualify — teach through the comments.
+
+  # Hard requirements (non-negotiable, enforced by gates)
+
+  1. Filename is `micro<name>.py` (packaging may rename, but produce lowercase
+     concatenated names in examples).
+  2. `random.seed(42)` is the first executable line after imports.
+  3. Stdlib-only imports. Permitted: `os`, `math`, `random`, `json`, `struct`,
+     `urllib`, `collections`, `itertools`, `functools`, `string`, `hashlib`,
+     `time`, `typing`, `dataclasses`. No NumPy, PyTorch, pip packages.
+  4. `python <file>.py` with zero arguments runs the full train + inference
+     (or demo) path. Must finish under 10 minutes on a laptop CPU, no GPU.
+  5. Datasets auto-download via `urllib` on first run, cached locally, max 5 MB.
+  6. 4-space indentation, 100-char max line length, `from __future__ import
+     annotations` enabled.
+
+  # Commenting standard (7 points — every script must include ALL of them)
+
+  1. **File thesis docstring.** Top-of-file triple-quoted docstring, one sentence,
+     states what the script PROVES. Not an API description.
+  2. **Section headers.** `# === SECTION NAME ===` dividers separating major
+     phases in this order: imports → constants → data loading → model/algorithm
+     → training loop (if applicable) → inference/demo.
+  3. **"Why" comments.** Explain reasoning, not what the code does. Never
+     paraphrase the next line.
+  4. **Math-to-code mappings.** Where the algorithm is defined mathematically,
+     show the equation and name each variable's correspondence (e.g. `x_t` in
+     the paper → `x` in the loop).
+  5. **Intuition comments.** Briefly explain why a technique works, not only
+     how it is coded.
+  6. **Signpost comments.** Flag every simplifying choice ("Signpost: single
+     head here; production uses N heads in parallel") and note what real
+     production systems do differently.
+  7. **No obvious comments.** Every comment must add information the code does
+     not convey. `# increment i` is banned.
+
+  Target 30-40% comment density. Acceptance test: a motivated engineer reads
+  the file top-to-bottom once and understands the algorithm without external
+  references.
+
+  # Docstrings
+
+  - Module docstring: the file thesis (one sentence).
+  - Public functions: Google-style with Args, Returns, Complexity (time AND
+    space).
+  - Never duplicate the thesis in function docstrings.
+
+  # __main__ block
+
+  - Minimum 3 assertions covering: normal case, edge case (empty / single /
+    boundary), and a stress or large case.
+  - On pass, print a one-line "all checks passed" summary.
+
+  If `validation_feedback` is present in session state, your previous attempt
+  failed. Fix ALL listed issues and regenerate the complete file.
+
+  Return only Python source code. No markdown fences. No prose.
 
 variables:
   - algorithm_name
@@ -18,23 +71,27 @@ variables:
   - reference_implementations
 
 user_prompt_template: |
-  Implement the {{ algorithm_name }} algorithm as a single Python file.
+  Implement the {{ algorithm_name }} algorithm as `micro{{ algorithm_name | lower | replace('_', '') | replace('-', '') }}.py`.
 
   Tier: {{ tier }}
   Description: {{ description }}
 
-  Reference implementations from the same tier (match this style):
+  # Reference implementations (canonical style — match them)
   {% for ref in reference_implementations %}
   --- {{ ref.name }} ---
   {{ ref.code }}
   {% endfor %}
 
-  Requirements:
-  1. Single file, zero external dependencies (stdlib only)
-  2. Type hints on all public function signatures
-  3. Google-style docstring with: summary, Args, Returns, Raises, Complexity (time and space)
-  4. At minimum 3 test cases in an `if __name__ == "__main__":` block covering:
-     - Normal case
-     - Edge case (empty input, single element, etc.)
-     - Large or stress case
-  5. Match the code style of the reference implementations above
+  # Checklist before you emit code
+
+  - [ ] File thesis docstring (one sentence, what this proves)
+  - [ ] `from __future__ import annotations` and stdlib-only imports
+  - [ ] `random.seed(42)` on the first executable line
+  - [ ] `# === SECTION NAME ===` headers in the required order
+  - [ ] Every non-trivial block has a Why / Intuition / Signpost / Math-to-code
+        comment where appropriate
+  - [ ] No "what" comments — no line restates what the code does
+  - [ ] ≥3 assertions in `if __name__ == "__main__":`, prints a pass line
+  - [ ] Runs under 10 minutes on CPU, no external packages
+
+  Emit the complete Python source code only.

--- a/src/apprentice/prompts/instrumentation.yaml
+++ b/src/apprentice/prompts/instrumentation.yaml
@@ -1,20 +1,41 @@
 name: instrumentation
-version: "1.0.0"
-description: "Adds trace hooks to an algorithm implementation for step-by-step observation"
+version: "2.0.0"
+description: "Adds trace hooks to a no-magic implementation without violating the house style"
 
 system_prompt: |
-  You are an expert in algorithm instrumentation for the no-magic educational project.
-  Your task is to add trace hooks to a clean algorithm implementation so that learners
-  can observe each meaningful step as it executes.
+  You add trace hooks to a clean no-magic algorithm implementation so learners
+  can observe each meaningful step at execution time. You must not degrade the
+  no-magic house style while doing so.
 
-  Instrumentation rules:
-  - Never alter the algorithm's correctness or time complexity class.
-  - Emit trace events by calling a provided `trace(event: str, **kwargs)` callback.
-  - Trace hooks must be placed at semantically meaningful points: comparisons, swaps,
-    assignments, recursive calls, and loop iterations that change state.
-  - Keep the original code structure intact — do not refactor or rename symbols.
-  - All trace calls must be guarded: only emit when a `trace` callable is provided.
-  - Preserve all existing type annotations and docstrings.
+  # Preservation rules (non-negotiable)
+
+  - Do not alter algorithmic correctness or time-complexity class.
+  - Preserve the file thesis docstring, `from __future__ import annotations`,
+    `random.seed(42)` first-executable-line rule, and all `# === SECTION
+    NAME ===` headers exactly as-is.
+  - Preserve every existing Why / Signpost / Intuition / Math-to-code comment.
+  - Stdlib-only imports remain stdlib-only; `trace` adds no dependencies.
+  - Do not rename symbols, refactor loops, or reformat code that is not being
+    hooked.
+  - Keep the original `if __name__ == "__main__":` block intact; add trace
+    usage as additional assertions, not replacements.
+
+  # How to hook
+
+  - Accept an optional `trace: Callable[..., None] | None = None` parameter on
+    the public entry-point function.
+  - Emit events with the provided `trace` callback at semantically meaningful
+    points: comparisons, swaps, assignments that change algorithm state,
+    recursive calls, iteration boundaries.
+  - Guard every trace call: `if trace is not None: trace(event, **kwargs)`.
+  - Each guarded call gets a Why-style comment explaining what learners are
+    meant to observe at that point (this IS part of the educational value).
+
+  # Docstrings
+
+  - Add a `Trace:` section to the entry-point docstring listing the event
+    names emitted and what each one reports.
+  - Do not rewrite existing Google-style Args/Returns/Complexity sections.
 
 variables:
   - algorithm_name
@@ -22,22 +43,25 @@ variables:
   - trace_format
 
 user_prompt_template: |
-  Add trace hooks to the following {{ algorithm_name }} implementation.
+  Add trace hooks to this {{ algorithm_name }} implementation.
 
-  Trace format specification:
+  # Trace format specification
   {{ trace_format }}
 
-  Original implementation:
+  # Original implementation (preserve all house-style elements verbatim)
   ```python
   {{ implementation_code }}
   ```
 
-  Requirements:
-  1. Accept an optional `trace` parameter (callable or None) on the main entry-point function.
-  2. Emit trace events using the format above at every meaningful algorithmic step.
-  3. Guard all trace calls: `if trace is not None: trace(...)`.
-  4. Do not change the algorithm's logic, complexity, or public API beyond adding the `trace` parameter.
-  5. Preserve all existing type annotations, docstrings, and the `if __name__ == "__main__":` block.
-  6. Add a docstring note explaining the trace parameter and the events it emits.
+  # Checklist before you emit code
 
-  Return **only** the instrumented Python source code inside a ```python ... ``` fence.
+  - [ ] File thesis docstring untouched
+  - [ ] `random.seed(42)` still the first executable line
+  - [ ] `# === SECTION NAME ===` headers untouched
+  - [ ] Existing Why / Signpost / Intuition comments untouched
+  - [ ] Every `trace` call guarded with `if trace is not None`
+  - [ ] Each hook site has a Why-comment explaining what it reveals
+  - [ ] Public API unchanged except for the new optional `trace` parameter
+  - [ ] `__main__` assertions still pass without the `trace` argument
+
+  Return the instrumented Python source code inside a ```python ... ``` fence.

--- a/tests/test_adk_orchestrator.py
+++ b/tests/test_adk_orchestrator.py
@@ -20,6 +20,7 @@ from apprentice.core.config import (
     StageBudgetConfig,
     TemplatesConfig,
 )
+from apprentice.core.gate_agent import GateAgent
 from apprentice.core.orchestrator import build_discovery_pipeline, build_pipeline
 
 
@@ -99,11 +100,26 @@ class TestBuildPipeline:
 
     def test_has_sub_agents_without_packaging(self) -> None:
         pipeline = build_pipeline(_model(), _config(), include_packaging=False)
-        assert len(pipeline.sub_agents) == 3
+        # impl + 2 impl gates + parallel + 2 artifact gates + review = 7
+        assert len(pipeline.sub_agents) == 7
 
     def test_has_sub_agents_with_packaging(self) -> None:
-        pipeline = build_pipeline(_model(), _config(), include_packaging=True)
-        assert len(pipeline.sub_agents) == 4
+        approval = {
+            "approved_by": "tester",
+            "approved_at": "2026-04-21T00:00:00+00:00",
+            "artifact_hashes": {},
+        }
+        pipeline = build_pipeline(
+            _model(), _config(), include_packaging=True, approval=approval
+        )
+        # build path (7) + review gate + packaging = 9
+        assert len(pipeline.sub_agents) == 9
+
+    def test_gate_agents_inserted(self) -> None:
+        pipeline = build_pipeline(_model(), _config(), include_packaging=False)
+        gate_agents = [a for a in pipeline.sub_agents if isinstance(a, GateAgent)]
+        gate_names = {g.gate.name for g in gate_agents}
+        assert gate_names == {"correctness", "lint", "consistency", "schema_compliance"}
 
     def test_parallel_agent_in_pipeline(self) -> None:
         pipeline = build_pipeline(_model(), _config())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from apprentice.cli import main
+import json
+from typing import TYPE_CHECKING, Any
+
+from apprentice.cli import _cmd_approve, _cmd_submit, main
+from apprentice.core.session_store import RunRecord, SessionStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestCLI:
@@ -23,3 +30,97 @@ class TestCLI:
     def test_status_command(self) -> None:
         result = main(["status"])
         assert result == 0
+
+
+class _ApproveArgs:
+    def __init__(self, run_id: str, approver: str | None = "tester") -> None:
+        self.run_id = run_id
+        self.approver = approver
+
+
+class _SubmitArgs:
+    def __init__(self, algorithm: str, run_id: str | None) -> None:
+        self.algorithm = algorithm
+        self.tier = 2
+        self.backend = None
+        self.model = None
+        self.run_id = run_id
+
+
+def _make_completed_run(store_dir: Path, algorithm: str) -> RunRecord:
+    store = SessionStore(store_dir=store_dir)
+    rec = store.create_run(algorithm, tier=2)
+    rec = store.complete_run(
+        rec,
+        session_state={
+            "algorithm_name": algorithm,
+            "generated_code": "print('hi')\n",
+        },
+        budget_summary={},
+        elapsed=1.0,
+    )
+    return rec
+
+
+class TestApproveCommand:
+    def test_approve_writes_approval_with_hashes(
+        self, tmp_path: Path, monkeypatch: Any, capsys: Any
+    ) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.session_store._DEFAULT_STORE_DIR", tmp_path / "sessions"
+        )
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        rec = _make_completed_run(tmp_path / "sessions", "selection")
+
+        code = _cmd_approve(_ApproveArgs(rec.run_id))
+        assert code == 0
+
+        out = json.loads(capsys.readouterr().out)
+        assert out["approved"] is True
+        assert out["approved_by"] == "tester"
+        assert "implementation" in out["artifact_hashes"]
+
+        store = SessionStore(store_dir=tmp_path / "sessions")
+        updated = store.load(rec.run_id)
+        approval = updated.session_state["review_approval"]
+        assert approval["approved_by"] == "tester"
+        assert approval["run_id"] == rec.run_id
+
+    def test_approve_rejects_missing_run(self, tmp_path: Path, monkeypatch: Any, capsys: Any) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.session_store._DEFAULT_STORE_DIR", tmp_path / "sessions"
+        )
+        code = _cmd_approve(_ApproveArgs("does-not-exist"))
+        assert code == 1
+        assert "Run not found" in capsys.readouterr().out
+
+
+class TestSubmitGuard:
+    def test_submit_blocks_without_approval(
+        self, tmp_path: Path, monkeypatch: Any, capsys: Any
+    ) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.session_store._DEFAULT_STORE_DIR", tmp_path / "sessions"
+        )
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        _make_completed_run(tmp_path / "sessions", "selection")
+
+        code = _cmd_submit(cfg=None, args=_SubmitArgs("selection", run_id=None))
+        assert code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert "apprentice approve" in out["remediation"]
+
+    def test_submit_requires_completed_run(
+        self, tmp_path: Path, monkeypatch: Any, capsys: Any
+    ) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.session_store._DEFAULT_STORE_DIR", tmp_path / "sessions"
+        )
+        code = _cmd_submit(cfg=None, args=_SubmitArgs("no-such-algo", run_id=None))
+        assert code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert "No completed build" in out["error"]

--- a/tests/test_gate_agent.py
+++ b/tests/test_gate_agent.py
@@ -1,0 +1,117 @@
+"""Tests for the GateAgent ADK wrapper and materialize_artifacts helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import anyio
+
+from apprentice.core.budget import BudgetTracker
+from apprentice.core.gate_agent import GateAgent, materialize_artifacts
+from apprentice.models.work_item import GateResult, GateVerdict, WorkItem
+
+if TYPE_CHECKING:
+    from apprentice.models.artifact import ArtifactBundle
+
+
+class _StubGate:
+    name = "stub"
+    max_retries = 0
+    blocking = True
+
+    def __init__(self, verdict: GateVerdict) -> None:
+        self._verdict = verdict
+        self.seen: list[str] = []
+
+    def evaluate(self, work_item: WorkItem, artifacts: ArtifactBundle) -> GateResult:
+        self.seen.append(work_item.algorithm_name)
+        return GateResult(
+            gate_name=self.name,
+            verdict=self._verdict,
+            diagnostics={"impl": artifacts.implementation_path},
+        )
+
+
+class _StubSession:
+    def __init__(self, state: dict[str, Any]) -> None:
+        self.state = state
+        self.id = "test-session"
+
+
+class _StubCtx:
+    def __init__(self, state: dict[str, Any]) -> None:
+        self.session = _StubSession(state)
+        self.invocation_id = "inv-1"
+        self.branch = None
+        self.end_invocation = False
+
+
+class TestMaterializeArtifacts:
+    def test_writes_every_provided_output(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        state = {
+            "algorithm_name": "selection",
+            "generated_code": "print('impl')\n",
+            "instrumented_code": "print('instr')\n",
+            "manim_scene_code": "print('scene')\n",
+            "anki_deck_content": "front,back,tags,type\n",
+        }
+        bundle = materialize_artifacts(state)
+        assert Path(bundle.implementation_path).read_text() == "print('impl')\n"
+        assert Path(bundle.instrumented_path).read_text() == "print('instr')\n"
+        assert Path(bundle.manim_scene_path).read_text() == "print('scene')\n"
+        assert Path(bundle.anki_deck_path).exists()
+
+    def test_omits_absent_outputs(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        bundle = materialize_artifacts({"algorithm_name": "selection"})
+        assert bundle.implementation_path == ""
+        assert bundle.instrumented_path == ""
+
+
+async def _collect(agen: Any) -> list[Any]:
+    return [event async for event in agen]
+
+
+class TestGateAgent:
+    def test_pass_records_verdict_and_continues(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        tracker = BudgetTracker(total_tokens=1000, total_usd=1.0)
+        gate = _StubGate(GateVerdict.PASS)
+        agent = GateAgent(gate, after_stage="implementation", tracker=tracker)
+        ctx = _StubCtx(
+            state={"algorithm_name": "selection", "generated_code": "print('ok')\n"}
+        )
+
+        events = anyio.run(_collect, agent._run_async_impl(ctx))
+
+        assert len(events) == 1
+        assert ctx.end_invocation is False
+        assert ctx.session.state["gate_verdicts"][-1]["verdict"] == GateVerdict.PASS.value
+        assert tracker.gate_verdicts[-1]["gate_name"] == "stub"
+        assert tracker.gate_verdicts[-1]["after_stage"] == "implementation"
+
+    def test_blocking_fail_ends_invocation(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "apprentice.core.gate_agent.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        tracker = BudgetTracker(total_tokens=1000, total_usd=1.0)
+        agent = GateAgent(
+            _StubGate(GateVerdict.FAIL), after_stage="implementation", tracker=tracker
+        )
+        ctx = _StubCtx(
+            state={"algorithm_name": "selection", "generated_code": "print('ok')\n"}
+        )
+
+        events = anyio.run(_collect, agent._run_async_impl(ctx))
+
+        assert len(events) == 1
+        assert ctx.end_invocation is True
+        assert ctx.session.state["gate_verdicts"][-1]["verdict"] == GateVerdict.FAIL.value

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from apprentice.gates.consistency import ConsistencyGate
 from apprentice.gates.correctness import CorrectnessGate
 from apprentice.gates.lint import LintGate
+from apprentice.gates.review import ReviewGate, compute_artifact_hashes
 from apprentice.gates.schema_compliance import SchemaComplianceGate
 from apprentice.models.artifact import ArtifactBundle
 from apprentice.models.work_item import GateVerdict, WorkItem
@@ -159,3 +160,56 @@ def gate_eval(
 ) -> object:
     item = _make_item(name)
     return gate.evaluate(item, bundle)
+
+
+class TestReviewGate:
+    def test_properties(self) -> None:
+        gate = ReviewGate()
+        assert gate.name == "review"
+        assert gate.blocking is True
+
+    def test_fail_when_no_approval(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text("print('ok')\n")
+        bundle = _make_bundle(implementation_path=str(f))
+        result = ReviewGate().evaluate(_make_item(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+        assert "no approval" in result.diagnostics["error"]
+        assert "apprentice approve" in result.diagnostics["remediation"]
+
+    def test_pass_with_matching_hashes(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text("print('ok')\n")
+        bundle = _make_bundle(implementation_path=str(f))
+        approval = {
+            "approved_by": "tester",
+            "approved_at": "2026-04-21T00:00:00+00:00",
+            "artifact_hashes": compute_artifact_hashes(bundle),
+        }
+        result = ReviewGate(approval=approval).evaluate(_make_item(), bundle)
+        assert result.verdict == GateVerdict.PASS
+        assert result.diagnostics["approved_by"] == "tester"
+
+    def test_fail_when_artifact_changed_after_approval(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text("print('ok')\n")
+        bundle = _make_bundle(implementation_path=str(f))
+        original_hashes = compute_artifact_hashes(bundle)
+        f.write_text("print('tampered')\n")
+        approval = {
+            "approved_by": "tester",
+            "approved_at": "2026-04-21T00:00:00+00:00",
+            "artifact_hashes": original_hashes,
+        }
+        result = ReviewGate(approval=approval).evaluate(_make_item(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+        assert "diffs" in result.diagnostics
+
+    def test_fail_on_incomplete_approval(self, tmp_path: Path) -> None:
+        f = tmp_path / "algo.py"
+        f.write_text("print('ok')\n")
+        bundle = _make_bundle(implementation_path=str(f))
+        approval = {"approved_by": "tester"}  # missing approved_at and hashes
+        result = ReviewGate(approval=approval).evaluate(_make_item(), bundle)
+        assert result.verdict == GateVerdict.FAIL
+        assert "missing fields" in result.diagnostics["error"]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -15,7 +15,7 @@ class TestLoadPrompt:
     def test_loads_implementation_prompt(self) -> None:
         template = load_prompt("implementation", _PROMPTS_DIR)
         assert template.name == "implementation"
-        assert template.version == "1.0.0"
+        assert template.version == "2.0.0"
         assert "algorithm_name" in template.variables
 
     def test_missing_prompt_raises(self) -> None:


### PR DESCRIPTION
## Summary

Closes the four pipeline-quality bugs filed against apprentice (#12, #13, #14, #15) in one coordinated change. The three architectural issues (#13, #14, #15) share a root cause — the ADK orchestrator was not evaluating the gate classes defined under `src/apprentice/gates/` — so they are fixed together. #12 (prompt tuning) is independent but shipped alongside because the tuned prompts make artifacts that the newly-wired gates will actually accept.

Six commits, each independently buildable and test-passing:

1. `feat(prompts)` — implementation + instrumentation prompts enforce no-magic house style
2. `feat(budget)` — per-stage tracker rows, gate verdicts, recursive callback wiring
3. `feat(core)` — `GateAgent` ADK wrapper for deterministic pipeline gates
4. `feat(gates)` — review gate with hash-signed approval
5. `feat(orchestrator)` — insert gates between stages, wire per-stage callbacks
6. `feat(cli)` — `apprentice approve` command and hash-guarded submit

## Issue-by-issue

### #12 — Prompts tuned for no-magic house style

The 2026-04-19 smoke run on `insertion_sort` produced clean educational code that did not satisfy `no-magic/.claude/CLAUDE.md` (missing `random.seed(42)`, no `# === SECTION ===` headers, no thesis docstring, no signpost / intuition / math-to-code comments).

- `src/apprentice/prompts/implementation.yaml` — enumerate the 7-point commenting standard verbatim in the system prompt; add a pre-flight checklist in the user prompt so the model self-audits before emitting code; hard-require `random.seed(42)` first line, stdlib-only imports (whitelisted), `micro<name>.py` naming, 10-min CPU cap, `__main__` block with ≥3 assertions.
- `src/apprentice/prompts/instrumentation.yaml` — add a preservation rule set so trace hooks do not strip the house-style elements the drafter just produced; guarded `if trace is not None` pattern; per-hook Why-comments.
- `src/apprentice/agents/implementation.py` — mirror the rules in `_DRAFTER_INSTRUCTION` (session state uses this constant, not the YAML file).

### #13 — Per-stage token and cost breakdown

Previous `budget_summary.per_agent` collapsed all six stages into one `apprentice_pipeline` row because ADK only fires the root SequentialAgent's callbacks. The tracker had no way to attribute output keys to their producing stage.

- `src/apprentice/core/budget.py`
  - New `wire_agent_callbacks(agent, tracker, model)` walks the agent tree and attaches the shared tracker's before/after callbacks to every node.
  - `_OUTPUT_KEY_BY_AGENT` map replaces the greedy unseen-key scan — each stage only claims its own output key.
  - `record_gate_verdict(...)` and a `gate_verdicts: list[dict]` field serialized in `to_dict()` so readers can confirm which gates ran, in what order, with what outcome.

### #14 — Review gate as a hard stop before submit

`src/apprentice/gates/review.py` was a 3-line stub; submit invoked packaging which invoked `open_pr` with no architectural gate. Confirmed on 2026-04-19 smoke test: gh was authed with `repo` scope and `open_pr` has no dry-run.

- `src/apprentice/gates/review.py` — full `ReviewGate`. Requires an approval payload with `{approved_by, approved_at, artifact_hashes}`. FAILs when no approval is recorded, when the payload is incomplete, or when any current artifact SHA-256 diverges from the approved hash (so any edit post-approval forces re-approval). Diagnostics name `apprentice approve <run_id>` explicitly.
- `compute_artifact_hashes(bundle)` is the shared hashing routine used by both the gate and the CLI.
- `src/apprentice/cli.py` — new `apprentice approve <run_id> [--approver X]` command. Loads the run record, materializes artifacts, hashes them, writes the approval onto the record.
- `apprentice submit` — now resolves the latest completed run (or takes `--run-id`), loads `review_approval` off the record, exits non-zero with remediation text when missing, and passes the approval into `build_pipeline`. The `ReviewGate` then verifies hashes still match at runtime before packaging.
- `src/apprentice/core/session_store.py` — add public `save(record)` so CLI does not reach into `_write`.

### #15 — Gates wired into the ADK orchestrator

`PipelineConfig.gates` and `Pipeline._evaluate_gates` existed but were not called by `core/orchestrator.py`, which is what `cli.py` actually runs. Correctness/lint/consistency/schema gates never blocked.

- `src/apprentice/core/gate_agent.py` (new) — `GateAgent(BaseAgent)` runs a `GateInterface` gate inside `_run_async_impl`, records the verdict into `state['gate_verdicts']` and the shared `BudgetTracker`, and sets `ctx.end_invocation = True` on a blocking FAIL so downstream sub-agents stop. `materialize_artifacts(state)` persists session-state outputs to a temp dir so gates that expect on-disk paths work.
- `src/apprentice/core/orchestrator.py` — `build_pipeline` inserts:
  - `CorrectnessGate` + `LintGate` after the implementation loop
  - `ConsistencyGate` + `SchemaComplianceGate` after the parallel artifact generation
  - `ReviewGate` before packaging when `include_packaging=True`
- Pipeline now has 7 sub-agents for build, 9 for submit (vs. 3 and 4 previously).

## Test plan

- [x] `uv run pytest` — 264 passing, 1 pre-existing unrelated failure (`test_config.py::test_provider` asserts `anthropic` backend while `config/apprentice.toml` is currently set to `openai`; unmodified by this PR).
- [x] `uv run ruff check src/ tests/` — all checks pass.
- [x] New: 4 tests in `tests/test_gate_agent.py` cover PASS / blocking-FAIL verdict recording, invocation termination, tracker attribution, and `materialize_artifacts` round-trips.
- [x] New: 4 `ReviewGate` tests in `tests/test_gates.py` cover missing-approval, hash-match PASS, hash-divergence FAIL, and incomplete-payload FAIL.
- [x] New: 4 CLI tests in `tests/test_cli.py` cover approve-writes-record, approve-rejects-missing-run, submit-blocks-without-approval, submit-requires-completed-run.
- [x] Updated: `tests/test_adk_orchestrator.py` reflects the new stage/gate sub-agent structure and asserts all four non-review gate agents are inserted.
- [x] Updated: `tests/test_prompts.py` version bump 1.0.0 → 2.0.0.

## Migration notes for operators

- `apprentice submit` now requires an approval step. Run `apprentice build <algo>`, review artifacts (they are materialized under `$TMPDIR/apprentice_artifacts/`), then `apprentice approve <run_id>` before `apprentice submit`. Any artifact edit after approval invalidates the hashes and forces re-approval — this is by design.
- `budget_summary.per_agent` now carries one row per stage plus one row per gate agent. Callers reading the aggregate `apprentice_pipeline` row should read from the total top-level fields (`tokens_used`, `cost_usd`) instead.
- Gate verdicts are available at `budget_summary.gate_verdicts` (ordered list) and in session state at `gate_verdicts`.

Refs: #12 #13 #14 #15