### PR TITLE
chore(provider): swap backend from anthropic to openai gpt-5.4

### DIFF
--- a/config/apprentice.toml
+++ b/config/apprentice.toml
@@ -40,9 +40,9 @@ half_open_probe_after_minutes = 60
 max_open_cycles_before_manual_reset = 3
 
 [provider]
-backend = "anthropic"
-model = "anthropic/claude-sonnet-4-20250514"
-fallback_model = "anthropic/claude-haiku-4-5-20251001"
+backend = "openai"
+model = "openai/gpt-5.4"
+fallback_model = "openai/gpt-5.4-mini"
 local_api_base = ""
 
 [observability]


### PR DESCRIPTION
## Summary

Updates the provider configuration in `config/apprentice.toml` to use the OpenAI backend with `gpt-5.4` as the primary model and `gpt-5.4-mini` as the fallback, replacing the prior Anthropic Claude Sonnet 4 / Haiku 4.5 pairing. Single commit, configuration-only change.

## What changes

### `config/apprentice.toml`

`[provider]` block:

| Field | Before | After |
|---|---|---|
| `backend` | `anthropic` | `openai` |
| `model` | `anthropic/claude-sonnet-4-20250514` | `openai/gpt-5.4` |
| `fallback_model` | `anthropic/claude-haiku-4-5-20251001` | `openai/gpt-5.4-mini` |

`local_api_base` and all other fields unchanged.

## Why now

Aligns `apprentice` with the application-level model standard recorded in the org-wide config standard (`gpt-4.1`, `gpt-5.4` family) for non-coding agent work. The previous Claude Sonnet 4 / Haiku 4.5 pairing was the bootstrap default; production runs are moving to the OpenAI standard.

This change does not touch agent orchestration models (Opus / Sonnet / Haiku used at the harness level for planning, parallel execution, and tests). Those remain as configured elsewhere — only the application-level provider that `apprentice` itself dispatches to is swapped.

## Test plan

- [ ] `apprentice` initializes without provider-resolution errors after this merge.
- [ ] A dry-run pipeline invocation reaches the OpenAI backend and receives a response.
- [ ] Fallback path exercised by inducing a primary-model failure; `gpt-5.4-mini` answers.
- [ ] Cost telemetry rolls up under the OpenAI provider in observability output.
- [ ] No regressions in the gates wired up by PR #16 (per the prior `fix:` commit on main).
- [ ] `local_api_base` left as empty string; no accidental local-endpoint activation.